### PR TITLE
Feature/slash by commitments

### DIFF
--- a/example/InclusionPreconfSlasher.sol
+++ b/example/InclusionPreconfSlasher.sol
@@ -105,7 +105,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
         TransactionCommitment memory txCommitment = abi.decode(commitment.commitment.payload, (TransactionCommitment));
 
         // If the inclusion proof is valid (doesn't revert) it means the challenge is fraudulent
-        _verifyInclusionProof(txCommitment, proof, delegation.commitmentsKey);
+        _verifyInclusionProof(txCommitment, proof, delegation.committer);
 
         // Delete the challenge
         delete challenges[challengeID];

--- a/example/InclusionPreconfSlasher.sol
+++ b/example/InclusionPreconfSlasher.sol
@@ -135,9 +135,6 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
         // recover the challenge ID from the commitment
         bytes32 challengeID = keccak256(abi.encode(commitment, delegation));
 
-        // decode the opaque commitment payload
-        TransactionCommitment memory txCommitment = abi.decode(commitment.payload, (TransactionCommitment));
-
         // It is assumed that this is function is called from the URC.slashCommitment() function. This check ensures that only the msg.sender that originates the chain of calls is able to slash the operator and ultimately claim the reward
         if (challenges[challengeID].challenger != challenger) {
             revert WrongChallengerAddress();
@@ -162,15 +159,11 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
         rewardAmountGwei = REWARD_AMOUNT_GWEI;
     }
 
-    function DOMAIN_SEPARATOR() external view returns (bytes memory) {
-        return "0xeeeeeeee";
-    }
-
     function _verifyInclusionProof(
         TransactionCommitment memory commitment,
         InclusionProof memory proof,
         address commitmentSigner
-    ) internal {
+    ) internal view {
         uint256 targetSlot = commitment.slot;
         if (targetSlot > _getCurrentSlot() - JUSTIFICATION_DELAY) {
             // We cannot open challenges for slots that are not finalized by Ethereum consensus yet.

--- a/example/InclusionPreconfSlasher.sol
+++ b/example/InclusionPreconfSlasher.sol
@@ -55,7 +55,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
 
     // claim that a transaction was not included in a block
     function createChallenge(
-        PreconfStructs.SignedCommitment calldata commitment,
+        SignedCommitmentTemp calldata commitment,
         ISlasher.SignedDelegation calldata signedDelegation
     ) external payable returns (bytes32 challengeID) {
         // Check that the attached bond amount is correct
@@ -75,9 +75,9 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
         address commitmentSigner = abi.decode(signedDelegation.delegation.metadata, (address));
 
         // Check if the delegation applies to the slot of the commitment
-        if (signedDelegation.delegation.validUntil < commitment.slot) {
-            revert DelegationExpired();
-        }
+        // if (signedDelegation.delegation.validUntil < commitment.slot) { // todo uncomment 
+        //     revert DelegationExpired();
+        // }
 
         // save the challenge
         challenges[challengeID] = Challenge({
@@ -90,7 +90,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
     // on success, the caller receives the challenge bond and the challenge is deleted
     function proveChallengeFraudulent(
         ISlasher.Delegation calldata delegation,
-        SignedCommitment calldata commitment,
+        SignedCommitmentTemp calldata commitment,
         InclusionProof calldata proof
     ) external {
         // recover the challenge
@@ -133,7 +133,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
         }
 
         // Recover the commitment from the evidence
-        SignedCommitment memory commitment = abi.decode(evidence, (SignedCommitment));
+        SignedCommitmentTemp memory commitment = abi.decode(evidence, (SignedCommitmentTemp));
 
         // recover the challenge ID from the commitment
         bytes32 challengeID = keccak256(abi.encode(commitment, delegation));
@@ -167,7 +167,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
     }
 
     function _verifyInclusionProof(
-        SignedCommitment memory commitment,
+        SignedCommitmentTemp memory commitment,
         InclusionProof memory proof,
         address commitmentSigner
     ) internal {
@@ -261,7 +261,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
     /// @return commitmentSigner The signer of the commitment.
     /// @return transactionData The decoded transaction data of the committed transaction.
     function _recoverCommitmentData(
-        SignedCommitment memory commitment
+        SignedCommitmentTemp memory commitment
     )
         internal
         pure
@@ -289,7 +289,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
     /// @param commitment The signed commitment to compute the ID for.
     /// @return commitmentID The computed commitment ID.
     function _computeCommitmentID(
-        SignedCommitment memory commitment
+        SignedCommitmentTemp memory commitment
     ) internal pure returns (bytes32) {
         return
             keccak256(

--- a/example/PreconfStructs.sol
+++ b/example/PreconfStructs.sol
@@ -26,7 +26,7 @@ interface PreconfStructs {
         uint256 challengeTimestamp;
     }
 
-    struct SignedCommitmentTemp {
+    struct TransactionCommitment {
         uint64 slot;
         bytes signature;
         bytes signedTx;

--- a/example/PreconfStructs.sol
+++ b/example/PreconfStructs.sol
@@ -26,7 +26,7 @@ interface PreconfStructs {
         uint256 challengeTimestamp;
     }
 
-    struct SignedCommitment {
+    struct SignedCommitmentTemp {
         uint64 slot;
         bytes signature;
         bytes signedTx;

--- a/example/StateLockSlasher.sol
+++ b/example/StateLockSlasher.sol
@@ -23,7 +23,6 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
     uint256 public SLASH_AMOUNT_GWEI;
-    uint256 public REWARD_AMOUNT_GWEI;
     address public constant BEACON_ROOTS_CONTRACT =
         0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
     uint256 public constant EIP4788_WINDOW = 8191;
@@ -32,9 +31,8 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
     uint256 public constant SLOT_TIME = 12;
     uint256 public ETH2_GENESIS_TIMESTAMP;
 
-    constructor(uint256 _slashAmountGwei, uint256 _rewardAmountGwei) {
+    constructor(uint256 _slashAmountGwei) {
         SLASH_AMOUNT_GWEI = _slashAmountGwei;
-        REWARD_AMOUNT_GWEI = _rewardAmountGwei;
 
         if (block.chainid == 17000) {
             // Holesky
@@ -53,7 +51,7 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
         ISlasher.Commitment calldata commitment,
         bytes calldata evidence,
         address challenger
-    ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
+    ) external returns (uint256 slashAmountGwei) {
         // Recover the slashing evidence
         // commitment: signature to EXCLUDE a tx
         // proof: MPT inclusion proof
@@ -77,7 +75,14 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
 
         // Return the slash amount to the URC slasher
         slashAmountGwei = SLASH_AMOUNT_GWEI;
-        rewardAmountGwei = REWARD_AMOUNT_GWEI;
+    }
+
+    function slashFromOptIn(
+        ISlasher.Commitment calldata commitment,
+        bytes calldata evidence,
+        address challenger
+    ) external returns (uint256 slashAmountGwei) {
+        // unused in this example
     }
 
     function _verifyInclusionProof(

--- a/example/StateLockSlasher.sol
+++ b/example/StateLockSlasher.sol
@@ -80,15 +80,11 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
         rewardAmountGwei = REWARD_AMOUNT_GWEI;
     }
 
-    function DOMAIN_SEPARATOR() external view returns (bytes memory) {
-        return "0xeeeeeeee";
-    }
-
     function _verifyInclusionProof(
         TransactionCommitment memory commitment,
         InclusionProof memory proof,
         address commitmentsKey
-    ) internal {
+    ) internal view {
         uint256 targetSlot = commitment.slot;
         if (targetSlot > _getCurrentSlot() - JUSTIFICATION_DELAY) {
             // We cannot open challenges for slots that are not finalized by Ethereum consensus yet.

--- a/example/StateLockSlasher.sol
+++ b/example/StateLockSlasher.sol
@@ -73,7 +73,7 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
         }
 
         // If the inclusion proof is valid (doesn't revert) they should be slashed for not excluding the transaction
-        _verifyInclusionProof(txCommitment, proof, delegation.commitmentsKey);
+        _verifyInclusionProof(txCommitment, proof, delegation.committer);
 
         // Return the slash amount to the URC slasher
         slashAmountGwei = SLASH_AMOUNT_GWEI;

--- a/example/StateLockSlasher.sol
+++ b/example/StateLockSlasher.sol
@@ -60,17 +60,17 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
         // commitment: signature to EXCLUDE a tx
         // proof: MPT inclusion proof
         (
-            SignedCommitment memory commitment,
+            SignedCommitmentTemp memory commitment,
             InclusionProof memory proof
         ) = abi.decode(
                 evidence,
-                (SignedCommitment, InclusionProof)
+                (SignedCommitmentTemp, InclusionProof)
             );
         
         // Check if the delegation applies to the slot of the commitment
-        if (delegation.validUntil < commitment.slot) {
-            revert DelegationExpired();
-        }
+        // if (delegation.validUntil < commitment.slot) { // todo uncomment
+        //     revert DelegationExpired();
+        // }
 
         // If the inclusion proof is valid (doesn't revert) they should be slashed for not excluding the transaction
         _verifyInclusionProof(commitment, proof, commitmentSigner);
@@ -85,7 +85,7 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
     }
 
     function _verifyInclusionProof(
-        SignedCommitment memory commitment,
+        SignedCommitmentTemp memory commitment,
         InclusionProof memory proof,
         address commitmentSigner
     ) internal {
@@ -179,7 +179,7 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
     /// @return commitmentSigner The signer of the commitment.
     /// @return transactionData The decoded transaction data of the committed transaction.
     function _recoverCommitmentData(
-        SignedCommitment memory commitment
+        SignedCommitmentTemp memory commitment
     )
         internal
         pure
@@ -207,7 +207,7 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
     /// @param commitment The signed commitment to compute the ID for.
     /// @return commitmentID The computed commitment ID.
     function _computeCommitmentID(
-        SignedCommitment memory commitment
+        SignedCommitmentTemp memory commitment
     ) internal pure returns (bytes32) {
         return
             keccak256(

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -35,12 +35,16 @@ interface IRegistry {
         uint32 unregisteredAt;
         /// The block number when slashed from breaking a commitment
         uint32 slashedAt;
+        /// Mapping to track opt-in and opt-out status for proposer commitment protocols
+        mapping(address slasher => SlasherCommitment) slasherCommitments;
     }
 
     /// @notice A struct to track opt-in and opt-out status for proposer commitment protocols
     struct SlasherCommitment {
         /// The block number when the operator opted in
         uint64 optedInAt;
+        /// The block number when the operator opted out
+        uint64 optedOutAt;
         /// The address of the key used for commitments
         address committer;
     }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -191,7 +191,6 @@ interface IRegistry {
 
     function slashCommitmentFromOptIn(
         bytes32 registrationRoot,
-        address slasher,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
     ) external returns (uint256 slashAmountGwei);

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -23,8 +23,8 @@ interface IRegistry {
 
     /// @notice An operator of BLS key[s]
     struct Operator {
-        /// The address used to deregister from the registry and claim collateral
-        address withdrawalAddress;
+        /// The authorized addresss for the operator
+        address owner;
         /// ETH collateral in GWEI
         uint56 collateralGwei;
         /// The block number when registration occurred
@@ -35,6 +35,16 @@ interface IRegistry {
         uint16 unregistrationDelay;
         /// The block number when slashed from breaking a commitment
         uint32 slashedAt;
+    }
+
+    /// @notice A struct to track opt-in and opt-out status for proposer commitment protocols
+    struct SlasherCommitment {
+        /// The block number when the operator opted in
+        uint64 optedInAt;
+        /// The block number when the operator opted out
+        uint64 optedOutAt;
+        /// The address of the key used for commitments
+        address committer;
     }
 
     /**
@@ -130,6 +140,9 @@ interface IRegistry {
     error InvalidDelegation();
     error DifferentSlots();
     error DelegationsAreSame();
+    error AlreadyOptedIn();
+    error NotOptedIn();
+    error OptInDelayNotMet();
     /**
      *
      *                                *

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -74,6 +74,12 @@ interface IRegistry {
         bytes32 registrationRoot, uint256 slashAmountGwei, uint256 rewardAmountGwei, BLS.G1Point pubkey
     );
 
+    /// @notice Emitted when an operator is slashed for equivocation
+    /// @param registrationRoot The merkle root of the registration merkle tree
+    /// @param rewardAmountGwei The amount of GWEI rewarded to the caller
+    /// @param pubkey The BLS public key
+    event OperatorEquivocated(bytes32 registrationRoot, uint256 rewardAmountGwei, BLS.G1Point pubkey);
+
     /// @notice Emitted when an operator is unregistered
     /// @param registrationRoot The merkle root of the registration merkle tree
     /// @param unregisteredAt The block number when the operator was unregistered
@@ -121,7 +127,9 @@ interface IRegistry {
     error NotSlashed();
     error SlashWindowNotMet();
     error UnauthorizedCommitment();
-
+    error InvalidDelegation();
+    error DifferentSlots();
+    error DelegationsAreSame();
     /**
      *
      *                                *
@@ -129,6 +137,7 @@ interface IRegistry {
      *                                *
      *
      */
+
     function register(Registration[] calldata registrations, address withdrawalAddress, uint16 unregistrationDelay)
         external
         payable
@@ -161,4 +170,11 @@ interface IRegistry {
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
     ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
+
+    function slashEquivocation(
+        bytes32 registrationRoot,
+        BLS.G2Point calldata registrationSignature,
+        bytes32[] calldata proof,
+        uint256 leafIndex
+    ) external;
 }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -27,6 +27,8 @@ interface IRegistry {
         address owner;
         /// ETH collateral in GWEI
         uint56 collateralGwei;
+        /// The number of keys registered per operator (capped at 255)
+        uint8 numKeys;
         /// The block number when registration occurred
         uint32 registeredAt;
         /// The block number when deregistration occurred

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -105,6 +105,13 @@ interface IRegistry {
     /// @param collateralGwei The amount of GWEI added
     event CollateralAdded(bytes32 registrationRoot, uint256 collateralGwei);
 
+    /// @notice Emitted when an operator is opted into a proposer commitment protocol
+    /// @param registrationRoot The merkle root of the registration merkle tree
+    /// @param slasher The address of the Slasher contract
+    /// @param committer The address of the key used for commitments
+    /// @param optedInAt The block number when the operator opted in
+    event OperatorOptedIn(bytes32 registrationRoot, address slasher, address committer, uint64 optedInAt);
+
     /**
      *
      *                                *

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -57,7 +57,9 @@ interface IRegistry {
     /// @param collateralGwei The collateral amount in GWEI
     /// @param owner The owner of the operator
     /// @param registeredAt The block number when the operator was registered
-    event OperatorRegistered(bytes32 indexed registrationRoot, uint256 collateralGwei, address owner, uint256 registeredAt);
+    event OperatorRegistered(
+        bytes32 indexed registrationRoot, uint256 collateralGwei, address owner, uint256 registeredAt
+    );
 
     /// @notice Emitted when a BLS key is registered
     /// @param leafIndex The index of the BLS key in the registration merkle tree
@@ -70,9 +72,7 @@ interface IRegistry {
     /// @param challenger The address of the challenger
     /// @param owner The owner of the operator
     /// @param reg The fraudulent registration
-    event RegistrationSlashed(
-        bytes32 indexed registrationRoot, address challenger, address owner, Registration reg
-    );
+    event RegistrationSlashed(bytes32 indexed registrationRoot, address challenger, address owner, Registration reg);
 
     /// @notice Emitted when an operator is slashed for breaking a commitment
     /// @param registrationRoot The merkle root of the registration merkle tree

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -120,6 +120,8 @@ interface IRegistry {
     error SlashingAlreadyOccurred();
     error NotSlashed();
     error SlashWindowNotMet();
+    error UnauthorizedCommitment();
+
     /**
      *
      *                                *
@@ -127,7 +129,6 @@ interface IRegistry {
      *                                *
      *
      */
-
     function register(Registration[] calldata registrations, address withdrawalAddress, uint16 unregistrationDelay)
         external
         payable
@@ -156,7 +157,8 @@ interface IRegistry {
         BLS.G2Point calldata registrationSignature,
         bytes32[] calldata proof,
         uint256 leafIndex,
-        ISlasher.SignedDelegation calldata signedDelegation,
+        ISlasher.SignedDelegation calldata delegation,
+        ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
     ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
 }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -112,6 +112,12 @@ interface IRegistry {
     /// @param optedInAt The block number when the operator opted in
     event OperatorOptedIn(bytes32 registrationRoot, address slasher, address committer, uint64 optedInAt);
 
+    /// @notice Emitted when an operator is opted out of a proposer commitment protocol
+    /// @param registrationRoot The merkle root of the registration merkle tree
+    /// @param slasher The address of the Slasher contract
+    /// @param optedOutAt The block number when the operator opted out
+    event OperatorOptedOut(bytes32 registrationRoot, address slasher, uint64 optedOutAt);
+
     /**
      *
      *                                *

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -166,10 +166,11 @@ interface IRegistry {
         payable
         returns (bytes32 registrationRoot);
 
-    function verifyMerkleProof(bytes32 registrationRoot, bytes32 leaf, bytes32[] calldata proof, uint256 leafIndex)
-        external
-        view
-        returns (uint256 collateralGwei);
+    function unregister(bytes32 registrationRoot) external;
+
+    function optInToSlasher(bytes32 registrationRoot, address slasher, address committer) external;
+
+    function optOutOfSlasher(bytes32 registrationRoot, address slasher) external;
 
     function slashRegistration(
         bytes32 registrationRoot,
@@ -178,18 +179,19 @@ interface IRegistry {
         uint256 leafIndex
     ) external returns (uint256 collateral);
 
-    function unregister(bytes32 registrationRoot) external;
-
-    function claimCollateral(bytes32 registrationRoot) external;
-
-    function addCollateral(bytes32 registrationRoot) external payable;
-
     function slashCommitment(
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
         bytes32[] calldata proof,
         uint256 leafIndex,
         ISlasher.SignedDelegation calldata delegation,
+        ISlasher.SignedCommitment calldata commitment,
+        bytes calldata evidence
+    ) external returns (uint256 slashAmountGwei);
+
+    function slashCommitmentFromOptIn(
+        bytes32 registrationRoot,
+        address slasher,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
     ) external returns (uint256 slashAmountGwei);
@@ -203,10 +205,29 @@ interface IRegistry {
         ISlasher.SignedDelegation calldata delegationTwo
     ) external returns (uint256 slashAmountGwei);
 
-    function slashCommitmentFromOptIn(
+    function addCollateral(bytes32 registrationRoot) external payable;
+
+    function claimCollateral(bytes32 registrationRoot) external;
+
+    function claimSlashedCollateral(bytes32 registrationRoot) external;
+
+    function verifyMerkleProof(bytes32 registrationRoot, bytes32 leaf, bytes32[] calldata proof, uint256 leafIndex)
+        external
+        view
+        returns (uint256 collateralGwei);
+
+    function getSlasherCommitment(bytes32 registrationRoot, address slasher)
+        external
+        view
+        returns (SlasherCommitment memory slasherCommitment);
+
+    function isOptedIntoSlasher(bytes32 registrationRoot, address slasher) external view returns (bool);
+
+    function getOptedInCommitter(
         bytes32 registrationRoot,
-        address slasher,
-        ISlasher.SignedCommitment calldata commitment,
-        bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei);
+        Registration calldata reg,
+        bytes32[] calldata proof,
+        uint256 leafIndex,
+        address slasher
+    ) external view returns (SlasherCommitment memory slasherCommitment, uint256 collateralGwei);
 }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -175,6 +175,8 @@ interface IRegistry {
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
         bytes32[] calldata proof,
-        uint256 leafIndex
+        uint256 leafIndex,
+        ISlasher.SignedDelegation calldata delegationOne,
+        ISlasher.SignedDelegation calldata delegationTwo
     ) external;
 }

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -51,11 +51,20 @@ interface ISlasher {
     /// @param evidence Arbitrary evidence for the slashing
     /// @param challenger The address of the challenger
     /// @return slashAmountGwei The amount of Gwei slashed
-    /// @return rewardAmountGwei The amount of Gwei rewarded to the caller
     function slash(
         Delegation calldata delegation,
         Commitment calldata commitment,
         bytes calldata evidence,
         address challenger
-    ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
+    ) external returns (uint256 slashAmountGwei);
+
+    /// @notice Slash an operator for a given commitment
+    /// @dev The URC will call this function to slash a registered operator if supplied with a valid commitment and evidence. The assumption is that the operator has opted into the slasher protocol on-chain.
+    /// @param commitment The commitment message
+    /// @param evidence Arbitrary evidence for the slashing
+    /// @param challenger The address of the challenger
+    /// @return slashAmountGwei The amount of Gwei slashed
+    function slashFromOptIn(Commitment calldata commitment, bytes calldata evidence, address challenger)
+        external
+        returns (uint256 slashAmountGwei);
 }

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -7,13 +7,11 @@ interface ISlasher {
     /// @notice A Delegation message from a proposer's BLS key to a delegate's BLS and ECDSA key
     struct Delegation {
         /// The proposer's BLS public key
-        BLS.G1Point proposerPubKey;
+        BLS.G1Point proposer;
         /// The delegate's BLS public key for Constraints API
-        BLS.G1Point constraintsKey;
+        BLS.G1Point delegate;
         /// The address of the delegate's ECDSA key for signing commitments
-        address commitmentsKey;
-        /// The address of the slasher contract
-        address slasher;
+        address committer;
         /// The slot number the delegation is valid for
         uint64 slot;
         /// Arbitrary metadata reserved for future use

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -4,17 +4,19 @@ pragma solidity >=0.8.0 <0.9.0;
 import { BLS } from "./lib/BLS.sol";
 
 interface ISlasher {
-    /// @notice A Delegation message from a proposer's BLS key to a delegate's BLS key
+    /// @notice A Delegation message from a proposer's BLS key to a delegate's BLS and ECDSA key
     struct Delegation {
         /// The proposer's BLS public key
         BLS.G1Point proposerPubKey;
-        /// The delegate's BLS public key
-        BLS.G1Point delegatePubKey;
+        /// The delegate's BLS public key for Constraints API
+        BLS.G1Point constraintsKey;
+        /// The address of the delegate's ECDSA key for signing commitments
+        address commitmentsKey;
         /// The address of the slasher contract
         address slasher;
-        /// The slot number after which the delegation expires
-        uint64 validUntil;
-        /// Arbitrary metadata reserved for use by the Slasher
+        /// The slot number the delegation is valid for
+        uint64 slot;
+        /// Arbitrary metadata reserved for future use
         bytes metadata;
     }
 
@@ -24,6 +26,24 @@ interface ISlasher {
         Delegation delegation;
         /// The signature of the delegation message
         BLS.G2Point signature;
+    }
+
+    /// @notice A Commitment message binding an opaque payload to a slasher contract
+    struct Commitment {
+        /// The type of commitment
+        uint64 commitmentType;
+        /// The payload of the commitment
+        bytes payload;
+        /// The address of the slasher contract
+        address slasher;
+    }
+
+    /// @notice A commitment message signed by a delegate's ECDSA key
+    struct SignedCommitment {
+        /// The commitment message
+        Commitment commitment;
+        /// The signature of the commitment message
+        bytes signature;
     }
 
     /// @notice Slash a proposer's BLS key for a given delegation

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -47,15 +47,19 @@ interface ISlasher {
     }
 
     /// @notice Slash a proposer's BLS key for a given delegation
-    /// @dev The URC will call this function to slash a registered operator if supplied with a valid delegation and evidence
+    /// @dev The URC will call this function to slash a registered operator if supplied with a valid commitment and evidence
     /// @param delegation The delegation message
+    /// @param commitment The commitment message
     /// @param evidence Arbitrary evidence for the slashing
     /// @param challenger The address of the challenger
     /// @return slashAmountGwei The amount of Gwei slashed
     /// @return rewardAmountGwei The amount of Gwei rewarded to the caller
-    function slash(Delegation calldata delegation, bytes calldata evidence, address challenger)
-        external
-        returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
+    function slash(
+        Delegation calldata delegation,
+        Commitment calldata commitment,
+        bytes calldata evidence,
+        address challenger
+    ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
 
     /// @notice The domain separator for the Slasher contract
     /// @dev The domain separator is used to prevent replay attacks from different Slasher contracts

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -58,9 +58,4 @@ interface ISlasher {
         bytes calldata evidence,
         address challenger
     ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
-
-    /// @notice The domain separator for the Slasher contract
-    /// @dev The domain separator is used to prevent replay attacks from different Slasher contracts
-    /// @return domainSeparator The domain separator
-    function DOMAIN_SEPARATOR() external view returns (bytes memory);
 }

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -325,7 +325,7 @@ contract Registry is IRegistry {
         );
 
         // Prevent slashing more than the operator's collateral
-        if (slashAmountGwei > operator.collateralGwei) {
+        if (slashAmountGwei > collateralGwei) {
             revert SlashAmountExceedsCollateral();
         }
 
@@ -373,7 +373,6 @@ contract Registry is IRegistry {
         bytes calldata evidence
     ) external returns (uint256 slashAmountGwei) {
         Operator storage operator = registrations[registrationRoot];
-        address owner = operator.owner;
 
         // Operator is not liable for slashings before the fraud proof window elapses
         if (block.number < operator.registeredAt + FRAUD_PROOF_WINDOW) {

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -27,7 +27,7 @@ contract Registry is IRegistry {
     uint32 public constant SLASH_WINDOW = 7200; // 1 day
     uint32 public constant OPT_IN_DELAY = 7200; // 1 day
     address internal constant BURNER_ADDRESS = address(0x0000000000000000000000000000000000000000);
-    bytes public constant DOMAIN_SEPARATOR = "0x00435255"; // "URC" in little endian
+    bytes public constant REGISTRATION_DOMAIN_SEPARATOR = "0x00435255"; // "URC" in little endian
     bytes public constant DELEGATION_DOMAIN_SEPARATOR = "0x0044656c"; // "Del" in little endian
 
     /**
@@ -39,7 +39,10 @@ contract Registry is IRegistry {
     /// @notice Batch registers an operator's BLS keys and collateral to the URC
     /// @dev Registration signatures are optimistically verified. They are expected to be signed with the `DOMAIN_SEPARATOR` mixin.
     /// @dev The function will merkleize the supplied `regs` and map the registration root to an Operator struct.
-    /// @dev The function will revert if the operator has already registered the same `regs`, if they sent less than `MIN_COLLATERAL`, if the unregistration delay is less than `MIN_UNREGISTRATION_DELAY`, or if the registration root is invalid.
+    /// @dev The function will revert if:
+    /// @dev - They sent less than `MIN_COLLATERAL` (InsufficientCollateral)
+    /// @dev - The operator has already registered the same `regs` (OperatorAlreadyRegistered)
+    /// @dev - The registration root is invalid (InvalidRegistrationRoot)
     /// @param regs The BLS keys to register
     /// @param owner The authorized address to perform actions on behalf of the operator
     /// @return registrationRoot The merkle root of the registration
@@ -48,20 +51,24 @@ contract Registry is IRegistry {
         payable
         returns (bytes32 registrationRoot)
     {
+        // At least MIN_COLLATERAL for sufficient reward for fraud/equivocation challenges
         if (msg.value < MIN_COLLATERAL) {
             revert InsufficientCollateral();
         }
 
+        // Construct tree root from registrations
         registrationRoot = _merkleizeRegistrations(regs);
 
         if (registrationRoot == bytes32(0)) {
             revert InvalidRegistrationRoot();
         }
 
+        // Prevent duplicates from overwriting previous registrations
         if (registrations[registrationRoot].registeredAt != 0) {
             revert OperatorAlreadyRegistered();
         }
 
+        // Each Operator is mapped to a unique registration root
         registrations[registrationRoot] = Operator({
             owner: owner,
             collateralGwei: uint56(msg.value / 1 gwei),
@@ -70,32 +77,39 @@ contract Registry is IRegistry {
             slashedAt: 0
         });
 
-        emit OperatorRegistered(registrationRoot, uint56(msg.value / 1 gwei), owner, block.number);
+        emit OperatorRegistered(registrationRoot, uint56(msg.value / 1 gwei), owner);
     }
 
     /// @notice Starts the process to unregister an operator from the URC
-    /// @dev The function will revert if the operator has already unregistered, if the operator has not registered, or if the caller is not the operator's withdrawal address.
     /// @dev The function will mark the `unregisteredAt` timestamp in the Operator struct. The operator can claim their collateral after the `unregistrationDelay` more blocks have passed.
+    /// @dev The function will revert if:
+    /// @dev - The operator has already unregistered (AlreadyUnregistered)
+    /// @dev - The operator has not registered (NotRegisteredKey)
+    /// @dev - The caller is not the operator's withdrawal address (WrongOperator)
     /// @param registrationRoot The merkle root generated and stored from the register() function
     function unregister(bytes32 registrationRoot) external {
         Operator storage operator = registrations[registrationRoot];
 
+        // Only the authorized owner can unregister
         if (operator.owner != msg.sender) {
             revert WrongOperator();
         }
 
-        // Check that they haven't already unregistered
+        // Prevent double unregistrations
         if (operator.unregisteredAt != type(uint32).max) {
             revert AlreadyUnregistered();
         }
 
-        // Set unregistration timestamp
+        // Save the block number; they must wait for the unregistration delay to claim collateral
         operator.unregisteredAt = uint32(block.number);
 
         emit OperatorUnregistered(registrationRoot, operator.unregisteredAt);
     }
+
     /// @notice Opts an operator into a proposer commtiment protocol via Slasher contract
-    /// @dev The function will revert if the operator has not registered or if the caller is not the operator's owner
+    /// @dev The function will revert if:
+    /// @dev - The operator has not registered (NotRegisteredKey)
+    /// @dev - The caller is not the operator's owner (WrongOperator)
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param slasher The address of the Slasher contract to opt into
     /// @param committer The address of the key used for commitments
@@ -103,57 +117,54 @@ contract Registry is IRegistry {
     function optInToSlasher(bytes32 registrationRoot, address slasher, address committer) external {
         Operator storage operator = registrations[registrationRoot];
 
+        // Only the authorized owner can opt in
         if (operator.owner != msg.sender) {
             revert WrongOperator();
         }
 
-        // Create a unique identifier for the slasher commitment
-        bytes32 slasherCommitmentId = keccak256(abi.encode(registrationRoot, slasher));
+        // Retrieve the SlasherCommitment struct
+        SlasherCommitment storage slasherCommitment =
+            slasherCommitments[keccak256(abi.encode(registrationRoot, slasher))];
 
-        // Cache the SlasherCommitment struct
-        SlasherCommitment storage slasherCommitment = slasherCommitments[slasherCommitmentId];
-
-        // Check if already opted in
-        if (slasherCommitment.optedOutAt < slasherCommitment.optedInAt) {
+        // Prevent double opt-ins
+        if (slasherCommitment.optedInAt != 0) {
             revert AlreadyOptedIn();
         }
 
-        // If previously opted out, enforce a delay before allowing new opt-in
-        if (slasherCommitment.optedOutAt != 0 && block.timestamp < slasherCommitment.optedOutAt + OPT_IN_DELAY) {
-            revert OptInDelayNotMet();
-        }
-
+        // Save the block number and committer
         slasherCommitment.optedInAt = uint64(block.number);
-        slasherCommitment.optedOutAt = 0;
         slasherCommitment.committer = committer;
 
-        emit OperatorOptedIn(registrationRoot, slasher, committer, slasherCommitment.optedInAt);
+        emit OperatorOptedIn(registrationRoot, slasher, committer);
     }
 
     /// @notice Opts out of a protocol for an operator
-    /// @dev The function will revert if the operator has not registered, if the caller is not the operator's owner, or if the operator is not opted into the protocol
+    /// @dev The function will revert if:
+    /// @dev - The caller is not the operator's owner (WrongOperator)
+    /// @dev - The opt-in delay has not passed (OptInDelayNotMet)
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param slasher The address of the Slasher contract to opt out of
     function optOutOfSlasher(bytes32 registrationRoot, address slasher) external {
         Operator storage operator = registrations[registrationRoot];
 
+        // Only the authorized owner can opt out
         if (operator.owner != msg.sender) {
             revert WrongOperator();
         }
 
+        // Retrieve the SlasherCommitment struct
         bytes32 slasherCommitmentId = keccak256(abi.encode(registrationRoot, slasher));
-
-        // Cache the SlasherCommitment struct
         SlasherCommitment storage slasherCommitment = slasherCommitments[slasherCommitmentId];
 
-        // Check if already opted out or never opted in
-        if (slasherCommitment.optedOutAt >= slasherCommitment.optedInAt) {
-            revert NotOptedIn();
+        // Enforce a delay before allowing opt-out
+        if (block.number < slasherCommitment.optedInAt + OPT_IN_DELAY) {
+            revert OptInDelayNotMet();
         }
 
-        slasherCommitment.optedOutAt = uint64(block.number);
+        // Delete the entry
+        delete slasherCommitments[slasherCommitmentId];
 
-        emit OperatorOptedOut(registrationRoot, slasher, slasherCommitment.optedOutAt);
+        emit OperatorOptedOut(registrationRoot, slasher);
     }
 
     /**
@@ -165,7 +176,12 @@ contract Registry is IRegistry {
     /// @notice Slash an operator for submitting a fraudulent `Registration` in the register() function
     /// @dev To save BLS verification gas costs, the URC optimistically accepts registration signatures. This function allows a challenger to slash the operator by executing the BLS verification to prove the registration is fraudulent.
     /// @dev The function will delete the operator's registration, transfer `MIN_COLLATERAL` to the caller, and return any remaining funds to the operator's withdrawal address.
-    /// @dev The function will revert if the operator has already unregistered, if the operator has not registered, if the fraud proof window has expired, or if the proof is invalid.
+    /// @dev The function will revert if:
+    /// @dev - The operator has already unregistered (AlreadyUnregistered)
+    /// @dev - The operator has not registered (NotRegisteredKey)
+    /// @dev - The fraud proof window has expired (FraudProofWindowExpired)
+    /// @dev - The proof is invalid (FraudProofChallengeInvalid)
+    /// @dev - ETH transfer to challenger or owner fails (EthTransferFailed)
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param reg The fraudulent Registration
     /// @param proof The merkle proof to verify the operator's key is in the registry
@@ -178,30 +194,33 @@ contract Registry is IRegistry {
         uint256 leafIndex
     ) external returns (uint256 slashedCollateralWei) {
         Operator storage operator = registrations[registrationRoot];
-        address operatorOwner = operator.owner;
+        address owner = operator.owner;
 
+        // Can only slash registrations within the fraud proof window
         if (block.number > operator.registeredAt + FRAUD_PROOF_WINDOW) {
             revert FraudProofWindowExpired();
         }
 
+        // Verify the registration is part of the registry
         uint256 collateralGwei = _verifyMerkleProof(registrationRoot, keccak256(abi.encode(reg)), proof, leafIndex);
 
+        // 0 collateral implies the registration was not part of the registry
         if (collateralGwei == 0) {
             revert NotRegisteredKey();
         }
 
         // Reconstruct registration message
-        bytes memory message = abi.encode(operatorOwner);
+        bytes memory message = abi.encode(owner);
 
-        // Verify registration signature
-        if (BLS.verify(message, reg.signature, reg.pubkey, DOMAIN_SEPARATOR)) {
+        // Verify registration signature, note the domain separator mixin
+        if (BLS.verify(message, reg.signature, reg.pubkey, REGISTRATION_DOMAIN_SEPARATOR)) {
             revert FraudProofChallengeInvalid();
         }
 
-        // Delete the operator
+        // Delete the operator, they must re-register to continue
         delete registrations[registrationRoot];
 
-        // Calculate the amount to transfer to challenger and return to operator
+        // Calculate the amount to transfer to challenger and return to owner
         uint256 remainingWei = uint256(collateralGwei) * 1 gwei - MIN_COLLATERAL;
 
         // Transfer to the challenger
@@ -210,21 +229,29 @@ contract Registry is IRegistry {
             revert EthTransferFailed();
         }
 
-        // Return any remaining funds to Operator
-        (success,) = operatorOwner.call{ value: remainingWei }("");
+        // Return any remaining funds to owner
+        (success,) = owner.call{ value: remainingWei }("");
         if (!success) {
             revert EthTransferFailed();
         }
 
-        emit RegistrationSlashed(registrationRoot, msg.sender, operatorOwner, reg);
+        emit OperatorSlashed(SlashingType.Fraud, registrationRoot, owner, msg.sender, address(this), MIN_COLLATERAL);
 
+        // Return a value for the caller to use
         return MIN_COLLATERAL;
     }
 
     /// @notice Slashes an operator for breaking a commitment
-    /// @dev The function verifies `proof` to first ensure the operator's key is in the registry, then verifies the `signedDelegation` was signed by the key. If the fraud proof window has passed, the URC will call the `slash()` function of the Slasher contract specified in the `signedDelegation`. The Slasher contract will determine if the operator has broken a commitment and return the amount of GWEI to be slashed at the URC.
-    /// @dev The function will burn `slashAmountGwei` and transfer `rewardAmountGwei` to the caller. It will also save the timestamp of the slashing to start the `SLASH_WINDOW` in case of multiple slashings.
-    /// @dev The function will revert if the operator has not registered, if the fraud proof window has not passed, if the operator has already unregistered, if the proof is invalid, or if the slash window has expired.
+    /// @dev The function verifies `proof` to first ensure the operator's BLS key is in the registry, then verifies the `signedDelegation` was signed by the same key. If the fraud proof window has passed, the URC will call the `slash()` function of the Slasher contract specified in the `signedCommitment`. The Slasher contract will determine if the operator has broken a commitment and return the amount of GWEI to be slashed at the URC.
+    /// @dev The function will burn `slashAmountGwei`. It will also save the timestamp of the slashing to start the `SLASH_WINDOW` in case of multiple slashings.
+    /// @dev The function will revert if:
+    /// @dev - The same slashing inputs have been supplied before (SlashingAlreadyOccurred)
+    /// @dev - The fraud proof window has not passed (FraudProofWindowNotMet)
+    /// @dev - The operator has already unregistered (OperatorAlreadyUnregistered)
+    /// @dev - The slash window has expired (SlashWindowExpired)
+    /// @dev - The proof is invalid (NotRegisteredKey)
+    /// @dev - The signed commitment was not signed by the delegated committer (DelegationSignatureInvalid)
+    /// @dev - The slash amount exceeds the operator's collateral (SlashAmountExceedsCollateral)
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param registrationSignature The signature from the operator's previously registered `Registration`
     /// @param proof The merkle proof to verify the operator's key is in the registry
@@ -233,7 +260,6 @@ contract Registry is IRegistry {
     /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
     /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
     /// @return slashAmountGwei The amount of GWEI slashed
-    /// @return rewardAmountGwei The amount of GWEI rewarded to the caller
     function slashCommitment(
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
@@ -242,61 +268,165 @@ contract Registry is IRegistry {
         ISlasher.SignedDelegation calldata delegation,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
+    ) external returns (uint256 slashAmountGwei) {
         Operator storage operator = registrations[registrationRoot];
 
         bytes32 slashingDigest = keccak256(abi.encode(delegation, commitment, registrationRoot));
 
+        // Prevent slashing with same inputs
         if (slashedBefore[slashingDigest]) {
             revert SlashingAlreadyOccurred();
         }
 
+        // Operator is not liable for slashings before the fraud proof window elapses
         if (block.number < operator.registeredAt + FRAUD_PROOF_WINDOW) {
             revert FraudProofWindowNotMet();
         }
 
+        // todo test operator.unregisteredAt + UNREGISTRATION_DELAY for overflow
+        // Operator is not liable for slashings after unregister and the delay has passed
         if (
             operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
         ) {
             revert OperatorAlreadyUnregistered();
         }
 
+        // Slashing can only occur within the slash window after the first reported slashing
+        // After the slash window has passed, the operator can claim collateral
         if (operator.slashedAt != 0 && block.number > operator.slashedAt + SLASH_WINDOW) {
             revert SlashWindowExpired();
         }
 
+        // Verify the delegation was signed by the operator's BLS key
+        // This is a sanity check to ensure the delegation is valid
         uint256 collateralGwei =
             _verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegation);
 
         // Verify the commitment was signed by the commitment key from the Delegation
         address committer = ECDSA.recover(keccak256(abi.encode(commitment.commitment)), commitment.signature);
-
         if (committer != delegation.delegation.committer) {
             revert UnauthorizedCommitment();
         }
 
-        (slashAmountGwei, rewardAmountGwei) =
-            _executeSlash(delegation.delegation, commitment.commitment, evidence, collateralGwei);
+        // Call the Slasher contract to slash the operator
+        slashAmountGwei = ISlasher(commitment.commitment.slasher).slash(
+            delegation.delegation, commitment.commitment, evidence, msg.sender
+        );
 
-        // Reward challenger + burn Ether
-        _executeSlashingTransfers(slashAmountGwei, rewardAmountGwei);
+        // Prevent slashing more than the operator's collateral
+        if (slashAmountGwei > operator.collateralGwei) {
+            revert SlashAmountExceedsCollateral();
+        }
 
-        // Save timestamp only once
+        // Burn the slashed amount
+        _burnGwei(slashAmountGwei);
+
+        // Save timestamp only once to start the slash window
         if (operator.slashedAt == 0) {
             operator.slashedAt = uint32(block.number);
         }
 
         // Decrement operator's collateral
-        operator.collateralGwei -= uint56(slashAmountGwei + rewardAmountGwei);
+        operator.collateralGwei -= uint56(slashAmountGwei);
 
         // Prevent same slashing from occurring again
         slashedBefore[slashingDigest] = true;
 
-        emit OperatorSlashed(registrationRoot, slashAmountGwei, rewardAmountGwei, delegation.delegation.proposer);
+        emit OperatorSlashed(
+            SlashingType.Commitment,
+            registrationRoot,
+            operator.owner,
+            msg.sender,
+            commitment.commitment.slasher,
+            slashAmountGwei
+        );
+    }
+
+    /// @notice Slashes an operator for breaking a commitment in a protocol they opted into via the optInToSlasher() function. The operator must have already opted into the protocol.
+    /// @dev The function verifies the commitment was signed by the registered committer from the optInToSlasher() function before calling into the Slasher contract.
+    /// @dev Reverts if:
+    /// @dev - The fraud proof window has not passed (FraudProofWindowNotMet)
+    /// @dev - The operator has already unregistered and delay passed (OperatorAlreadyUnregistered)
+    /// @dev - The slash window has expired (SlashWindowExpired)
+    /// @dev - The operator has not opted into the slasher (NotOptedIn)
+    /// @dev - The commitment was not signed by registered committer (UnauthorizedCommitment)
+    /// @dev - The slash amount exceeds operator's collateral (SlashAmountExceedsCollateral)
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param slasher The address of the Slasher contract
+    /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
+    /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
+    function slashCommitmentFromOptIn(
+        bytes32 registrationRoot,
+        address slasher,
+        ISlasher.SignedCommitment calldata commitment,
+        bytes calldata evidence
+    ) external returns (uint256 slashAmountGwei) {
+        Operator storage operator = registrations[registrationRoot];
+        address owner = operator.owner;
+
+        // Operator is not liable for slashings before the fraud proof window elapses
+        if (block.number < operator.registeredAt + FRAUD_PROOF_WINDOW) {
+            revert FraudProofWindowNotMet();
+        }
+
+        // todo test operator.unregisteredAt + UNREGISTRATION_DELAY for overflow
+        // Operator is not liable for slashings after unregister and the delay has passed
+        if (
+            operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
+        ) {
+            revert OperatorAlreadyUnregistered();
+        }
+
+        // Slashing can only occur within the slash window after the first reported slashing
+        // After the slash window has passed, the operator can claim collateral
+        if (operator.slashedAt != 0 && block.number > operator.slashedAt + SLASH_WINDOW) {
+            revert SlashWindowExpired();
+        }
+
+        // Recover the SlasherCommitment entry
+        bytes32 slasherCommitmentId = keccak256(abi.encode(registrationRoot, slasher));
+        SlasherCommitment storage slasherCommitment = slasherCommitments[slasherCommitmentId];
+
+        // Verify the operator is opted into protocol
+        if (slasherCommitment.optedInAt == 0) {
+            revert NotOptedIn();
+        }
+
+        // Verify the commitment was signed by the registered committer from the optInToSlasher() function
+        address committer = ECDSA.recover(keccak256(abi.encode(commitment.commitment)), commitment.signature);
+        if (committer != slasherCommitment.committer) {
+            revert UnauthorizedCommitment();
+        }
+
+        // Call the Slasher contract to slash the operator
+        slashAmountGwei = ISlasher(slasher).slashFromOptIn(commitment.commitment, evidence, msg.sender);
+
+        // Prevent slashing more than the operator's collateral
+        if (slashAmountGwei > operator.collateralGwei) {
+            revert SlashAmountExceedsCollateral();
+        }
+
+        // Save timestamp only once to start the slash window
+        if (operator.slashedAt == 0) {
+            operator.slashedAt = uint32(block.number);
+        }
+
+        // Decrement operator's collateral
+        operator.collateralGwei -= uint56(slashAmountGwei);
+
+        // Prevent same slashing from occurring again
+        delete slasherCommitments[slasherCommitmentId];
+
+        emit OperatorSlashed(
+            SlashingType.Commitment, registrationRoot, operator.owner, msg.sender, slasher, slashAmountGwei
+        );
+
+        // Burn the slashed amount
+        _burnGwei(slashAmountGwei);
     }
 
     /// @notice Slash an operator for equivocation (signing two different delegations for the same slot)
-    /// @dev The function will slash the operator's collateral and transfer `MIN_COLLATERAL` to the caller
+    /// @dev The function will slash the operator's collateral and transfer `MIN_COLLATERAL` to the msg.sender.
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param registrationSignature The signature from the operator's previously registered `Registration`
     /// @param proof The merkle proof to verify the operator's key is in the registry
@@ -318,69 +448,79 @@ contract Registry is IRegistry {
         uint256 leafIndex,
         ISlasher.SignedDelegation calldata delegationOne,
         ISlasher.SignedDelegation calldata delegationTwo
-    ) external {
+    ) external returns (uint256 slashAmountGwei) {
         Operator storage operator = registrations[registrationRoot];
 
         bytes32 slashingDigest = keccak256(abi.encode(delegationOne, delegationTwo, registrationRoot));
 
-        // verify the delegations are not the same
+        // Verify the delegations are not identical
         if (keccak256(abi.encode(delegationOne)) == keccak256(abi.encode(delegationTwo))) {
             revert DelegationsAreSame();
         }
 
+        // Prevent duplicate slashing with same inputs
         if (slashedBefore[slashingDigest]) {
             revert SlashingAlreadyOccurred();
         }
 
+        // Operator is not liable for slashings before the fraud proof window elapses
         if (block.number < operator.registeredAt + FRAUD_PROOF_WINDOW) {
             revert FraudProofWindowNotMet();
         }
 
+        // todo test operator.unregisteredAt + UNREGISTRATION_DELAY for overflow
+        // Operator is not liable for slashings after unregister and the delay has passed
         if (
             operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
         ) {
             revert OperatorAlreadyUnregistered();
         }
 
+        // Slashing can only occur within the slash window after the first reported slashing
+        // After the slash window has passed, the operator can claim collateral
         if (operator.slashedAt != 0 && block.number > operator.slashedAt + SLASH_WINDOW) {
             revert SlashWindowExpired();
         }
 
-        // verify both delegations
-        uint256 collateralGweiOne =
-            _verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationOne);
-        uint256 collateralGweiTwo =
-            _verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationTwo);
-
+        // Verify both delegations were signed by the operator's BLS key
+        if (_verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationOne) == 0) {
+            revert InvalidDelegation();
+        }
         // error if either delegation is invalid
-        if (collateralGweiOne == 0 || collateralGweiTwo == 0) {
+        if (_verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationTwo) == 0) {
             revert InvalidDelegation();
         }
 
-        // error if the delegations are for different slots
+        // Verify the delegations are for the same slot
         if (delegationOne.delegation.slot != delegationTwo.delegation.slot) {
             revert DifferentSlots();
         }
 
-        // Save timestamp only once
+        // Save timestamp only once to start the slash window
         if (operator.slashedAt == 0) {
             operator.slashedAt = uint32(block.number);
         }
 
-        // Decrement operator's collateral
-        operator.collateralGwei -= uint56(MIN_COLLATERAL / 1 gwei);
+        slashAmountGwei = MIN_COLLATERAL / 1 gwei;
 
-        // Save both permutations of the slashing digest
+        // Decrement operator's collateral
+        operator.collateralGwei -= uint56(slashAmountGwei);
+
+        // Prevent same slashing from occurring again
         slashedBefore[slashingDigest] = true;
+
+        // Save the perumutation to prevent duplicate slashings with the same pair of Delegations
         slashedBefore[keccak256(abi.encode(delegationTwo, delegationOne, registrationRoot))] = true;
 
-        // reward the challenger
+        // Reward the challenger
         (bool success,) = msg.sender.call{ value: MIN_COLLATERAL }("");
         if (!success) {
             revert EthTransferFailed();
         }
 
-        emit OperatorEquivocated(registrationRoot, MIN_COLLATERAL, delegationOne.delegation.proposer);
+        emit OperatorSlashed(
+            SlashingType.Equivocation, registrationRoot, operator.owner, msg.sender, address(this), slashAmountGwei
+        );
     }
 
     /**
@@ -430,13 +570,11 @@ contract Registry is IRegistry {
             revert NoCollateralToClaim();
         }
 
-        uint256 amountToReturn = collateralGwei * 1 gwei;
-
         // Clear operator info
         delete registrations[registrationRoot];
 
         // Transfer to operator
-        (bool success,) = operatorOwner.call{ value: amountToReturn }("");
+        (bool success,) = operatorOwner.call{ value: collateralGwei * 1 gwei }("");
         if (!success) {
             revert EthTransferFailed();
         }
@@ -446,7 +584,7 @@ contract Registry is IRegistry {
 
     function claimSlashedCollateral(bytes32 registrationRoot) external {
         Operator storage operator = registrations[registrationRoot];
-        address operatorOwner = operator.owner;
+        address owner = operator.owner;
         uint256 collateralGwei = operator.collateralGwei;
 
         // Check that they've been slashed
@@ -459,13 +597,11 @@ contract Registry is IRegistry {
             revert SlashWindowNotMet();
         }
 
-        uint256 amountToReturn = collateralGwei * 1 gwei;
-
-        // Clear operator info
+        // Delete the operator
         delete registrations[registrationRoot];
 
-        // Transfer to operator
-        (bool success,) = operatorOwner.call{ value: amountToReturn }("");
+        // Transfer collateral to owner
+        (bool success,) = owner.call{ value: collateralGwei * 1 gwei }("");
         if (!success) {
             revert EthTransferFailed();
         }
@@ -562,26 +698,26 @@ contract Registry is IRegistry {
         }
     }
 
-    /// @notice Executes the slash function of the Slasher contract and returns the amount of GWEI to be slashed
-    /// @dev The function will revert if the `slashAmountGwei` is 0, if the `slashAmountGwei` exceeds the operator's collateral, or if the Slasher.slash() function reverts.
-    /// @param delegation The SignedDelegation signed by the operator's BLS key
-    /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
-    /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
-    /// @param collateralGwei The operator's collateral amount in GWEI
-    /// @return slashAmountGwei The amount of GWEI to be slashed
-    function _executeSlash(
-        ISlasher.Delegation calldata delegation,
-        ISlasher.Commitment calldata commitment,
-        bytes calldata evidence,
-        uint256 collateralGwei
-    ) internal returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
-        (slashAmountGwei, rewardAmountGwei) =
-            ISlasher(commitment.slasher).slash(delegation, commitment, evidence, msg.sender);
+    // /// @notice Executes the slash function of the Slasher contract and returns the amount of GWEI to be slashed
+    // /// @dev The function will revert if the `slashAmountGwei` is 0, if the `slashAmountGwei` exceeds the operator's collateral, or if the Slasher.slash() function reverts.
+    // /// @param delegation The SignedDelegation signed by the operator's BLS key
+    // /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
+    // /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
+    // /// @param collateralGwei The operator's collateral amount in GWEI
+    // /// @return slashAmountGwei The amount of GWEI to be slashed
+    // function _executeSlash(
+    //     ISlasher.Delegation calldata delegation,
+    //     ISlasher.Commitment calldata commitment,
+    //     bytes calldata evidence,
+    //     uint256 collateralGwei
+    // ) internal returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
+    //     (slashAmountGwei, rewardAmountGwei) =
+    //         ISlasher(commitment.slasher).slash(delegation, commitment, evidence, msg.sender);
 
-        if (slashAmountGwei > collateralGwei) {
-            revert SlashAmountExceedsCollateral();
-        }
-    }
+    //     if (slashAmountGwei > collateralGwei) {
+    //         revert SlashAmountExceedsCollateral();
+    //     }
+    // }
 
     /// @notice Distributes rewards to the challenger and burns the slash amount
     /// @dev The function will revert if the transfer to the slasher fails or if the rewardAmountGwei is less than `MIN_COLLATERAL`.
@@ -596,6 +732,17 @@ contract Registry is IRegistry {
 
         // Transfer to the challenger
         (success,) = msg.sender.call{ value: rewardAmountGwei * 1 gwei }("");
+        if (!success) {
+            revert EthTransferFailed();
+        }
+    }
+
+    /// @notice Burns ether
+    /// @dev The function will revert if the transfer to the BURNER_ADDRESS fails.
+    /// @param amountGwei The amount of GWEI to be burned
+    function _burnGwei(uint256 amountGwei) internal {
+        // Burn the slash amount
+        (bool success,) = BURNER_ADDRESS.call{ value: amountGwei * 1 gwei }("");
         if (!success) {
             revert EthTransferFailed();
         }

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -113,6 +113,9 @@ contract Registry is IRegistry {
     /// @dev The function will revert if:
     /// @dev - The operator has not registered (NotRegisteredKey)
     /// @dev - The caller is not the operator's owner (WrongOperator)
+    /// @dev - The fraud proof window has not passed (FraudProofWindowNotMet)
+    /// @dev - The operator has already opted in (AlreadyOptedIn)
+    /// @dev - The opt-in delay has not passed (OptInDelayNotMet)
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param slasher The address of the Slasher contract to opt into
     /// @param committer The address of the key used for commitments
@@ -123,6 +126,11 @@ contract Registry is IRegistry {
         // Only the authorized owner can opt in
         if (operator.owner != msg.sender) {
             revert WrongOperator();
+        }
+
+        // Operator cannot opt in before the fraud proof window elapses
+        if (block.number < operator.registeredAt + FRAUD_PROOF_WINDOW) {
+            revert FraudProofWindowNotMet();
         }
 
         // Retrieve the SlasherCommitment struct

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -72,6 +72,7 @@ contract Registry is IRegistry {
         registrations[registrationRoot] = Operator({
             owner: owner,
             collateralGwei: uint56(msg.value / 1 gwei),
+            numKeys: uint8(regs.length),
             registeredAt: uint32(block.number),
             unregisteredAt: type(uint32).max,
             slashedAt: 0

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -29,20 +29,6 @@ contract Registry is IRegistry {
     address internal constant BURNER_ADDRESS = address(0x0000000000000000000000000000000000000000);
     bytes public constant DOMAIN_SEPARATOR = "0x00435255"; // "URC" in little endian
     bytes public constant DELEGATION_DOMAIN_SEPARATOR = "0x0044656c"; // "Del" in little endian
-    uint256 public ETH2_GENESIS_TIMESTAMP;
-
-    constructor() {
-        if (block.chainid == 17000) {
-            // Holesky
-            ETH2_GENESIS_TIMESTAMP = 1695902400;
-        } else if (block.chainid == 1) {
-            // Mainnet
-            ETH2_GENESIS_TIMESTAMP = 1606824023;
-        } else if (block.chainid == 7014190335) {
-            // Helder
-            ETH2_GENESIS_TIMESTAMP = 1718967660;
-        }
-    }
 
     /// @notice Batch registers an operator's BLS keys and collateral to the registry
     /// @dev Registration signatures are optimistically verified. They are expected to be signed with the `DOMAIN_SEPARATOR` mixin.
@@ -603,12 +589,5 @@ contract Registry is IRegistry {
         if (!success) {
             revert EthTransferFailed();
         }
-    }
-
-    /// @notice Get the slot number from a given timestamp. Assumes 12 second slot time.
-    /// @param _timestamp The timestamp
-    /// @return slot The slot number
-    function _getSlotFromTimestamp(uint256 _timestamp) internal view returns (uint256 slot) {
-        slot = (_timestamp - ETH2_GENESIS_TIMESTAMP) / 12;
     }
 }

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -363,16 +363,15 @@ contract Registry is IRegistry {
     /// @dev - The commitment was not signed by registered committer (UnauthorizedCommitment)
     /// @dev - The slash amount exceeds operator's collateral (SlashAmountExceedsCollateral)
     /// @param registrationRoot The merkle root generated and stored from the register() function
-    /// @param slasher The address of the Slasher contract
     /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
     /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
     function slashCommitmentFromOptIn(
         bytes32 registrationRoot,
-        address slasher,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
     ) external returns (uint256 slashAmountGwei) {
         Operator storage operator = registrations[registrationRoot];
+        address slasher = commitment.commitment.slasher;
 
         // Operator is not liable for slashings before the fraud proof window elapses
         if (block.number < operator.registeredAt + FRAUD_PROOF_WINDOW) {

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -283,7 +283,6 @@ contract Registry is IRegistry {
             revert FraudProofWindowNotMet();
         }
 
-        // todo test operator.unregisteredAt + UNREGISTRATION_DELAY for overflow
         // Operator is not liable for slashings after unregister and the delay has passed
         if (
             operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
@@ -369,7 +368,6 @@ contract Registry is IRegistry {
             revert FraudProofWindowNotMet();
         }
 
-        // todo test operator.unregisteredAt + UNREGISTRATION_DELAY for overflow
         // Operator is not liable for slashings after unregister and the delay has passed
         if (
             operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
@@ -468,7 +466,6 @@ contract Registry is IRegistry {
             revert FraudProofWindowNotMet();
         }
 
-        // todo test operator.unregisteredAt + UNREGISTRATION_DELAY for overflow
         // Operator is not liable for slashings after unregister and the delay has passed
         if (
             operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
@@ -695,45 +692,6 @@ contract Registry is IRegistry {
 
         if (!BLS.verify(message, delegation.signature, delegation.delegation.proposer, DELEGATION_DOMAIN_SEPARATOR)) {
             revert DelegationSignatureInvalid();
-        }
-    }
-
-    // /// @notice Executes the slash function of the Slasher contract and returns the amount of GWEI to be slashed
-    // /// @dev The function will revert if the `slashAmountGwei` is 0, if the `slashAmountGwei` exceeds the operator's collateral, or if the Slasher.slash() function reverts.
-    // /// @param delegation The SignedDelegation signed by the operator's BLS key
-    // /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
-    // /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
-    // /// @param collateralGwei The operator's collateral amount in GWEI
-    // /// @return slashAmountGwei The amount of GWEI to be slashed
-    // function _executeSlash(
-    //     ISlasher.Delegation calldata delegation,
-    //     ISlasher.Commitment calldata commitment,
-    //     bytes calldata evidence,
-    //     uint256 collateralGwei
-    // ) internal returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
-    //     (slashAmountGwei, rewardAmountGwei) =
-    //         ISlasher(commitment.slasher).slash(delegation, commitment, evidence, msg.sender);
-
-    //     if (slashAmountGwei > collateralGwei) {
-    //         revert SlashAmountExceedsCollateral();
-    //     }
-    // }
-
-    /// @notice Distributes rewards to the challenger and burns the slash amount
-    /// @dev The function will revert if the transfer to the slasher fails or if the rewardAmountGwei is less than `MIN_COLLATERAL`.
-    /// @param slashAmountGwei The amount of GWEI to be burned
-    /// @param rewardAmountGwei The amount of GWEI to be transferred to the caller
-    function _executeSlashingTransfers(uint256 slashAmountGwei, uint256 rewardAmountGwei) internal {
-        // Burn the slash amount
-        (bool success,) = BURNER_ADDRESS.call{ value: slashAmountGwei * 1 gwei }("");
-        if (!success) {
-            revert EthTransferFailed();
-        }
-
-        // Transfer to the challenger
-        (success,) = msg.sender.call{ value: rewardAmountGwei * 1 gwei }("");
-        if (!success) {
-            revert EthTransferFailed();
         }
     }
 

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -34,18 +34,18 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
     uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
     uint256 rewardAmountGwei = 0.1 ether / 1 gwei; // reward 0.1 ether
     uint256 collateral = 1.1 ether;
-    uint256 commitmentSecretKey;
-    address commitmentKey;
+    uint256 committerSecretKey;
+    address committer;
 
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
         registry = new Registry();
         slasher = new InclusionPreconfSlasher(slashAmountGwei, rewardAmountGwei, address(registry));
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
-        (commitmentKey, commitmentSecretKey) = makeAddrAndKey("commitmentsKey");
+        (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
         vm.deal(challenger, 100 ether);
         vm.deal(operator, 100 ether);
-        vm.deal(commitmentKey, 100 ether);
+        vm.deal(committer, 100 ether);
     }
 
     function setupRegistration(address operator, address delegate, uint64 slot)
@@ -61,8 +61,8 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(slasher),
             domainSeparator: slasher.DOMAIN_SEPARATOR(),
             metadata: metadata,
@@ -99,8 +99,8 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
 
         // Delegate signs a commitment to include a TX
         TransactionCommitment memory txCommitment =
-            _createInclusionCommitment(inclusionBlockNumber, id, commitmentKey, commitmentSecretKey);
-        signedCommitment = basicCommitment(commitmentSecretKey, address(slasher), abi.encode(txCommitment));
+            _createInclusionCommitment(inclusionBlockNumber, id, committer, committerSecretKey);
+        signedCommitment = basicCommitment(committerSecretKey, address(slasher), abi.encode(txCommitment));
 
         // Build the inclusion proof to prove failure to exclude
         string memory rawPreviousHeader = vm.readFile("./test/testdata/header_20785011.json");
@@ -186,8 +186,8 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
             collateral: collateral,
             withdrawalAddress: alice,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(slasher),
             domainSeparator: slasher.DOMAIN_SEPARATOR(),
             metadata: metadata,
@@ -202,7 +202,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
             _createInclusionCommitment(inclusionBlockNumber, 1, delegate, delegatePK);
 
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(commitmentSecretKey, address(slasher), abi.encode(commitment));
+            basicCommitment(committerSecretKey, address(slasher), abi.encode(commitment));
 
         // Try to create challenge with expired delegation
         uint256 bond = slasher.CHALLENGE_BOND();

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -64,7 +64,6 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(slasher),
-            domainSeparator: slasher.DOMAIN_SEPARATOR(),
             metadata: metadata,
             slot: slot
         });
@@ -83,8 +82,6 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         )
     {
         uint256 inclusionBlockNumber = 20_785_012;
-        // Create ecdsa keypair for delegate
-        (address delegate, uint256 delegatePK) = makeAddrAndKey("delegate");
 
         // Advance before the fraud proof window
         vm.roll(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW());
@@ -189,7 +186,6 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(slasher),
-            domainSeparator: slasher.DOMAIN_SEPARATOR(),
             metadata: metadata,
             slot: 0 // already expired
          });

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -253,7 +253,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         );
 
         // Retrieve operator data
-        IRegistry.Operator memory operatorData = getRegistrationData(result.registrationRoot);
+        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -32,7 +32,6 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
     InclusionPreconfSlasher slasher;
     BLS.G1Point delegatePubKey;
     uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
-    uint256 rewardAmountGwei = 0.1 ether / 1 gwei; // reward 0.1 ether
     uint256 collateral = 1.1 ether;
     uint256 committerSecretKey;
     address committer;
@@ -40,7 +39,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
         registry = new Registry();
-        slasher = new InclusionPreconfSlasher(slashAmountGwei, rewardAmountGwei, address(registry));
+        slasher = new InclusionPreconfSlasher(slashAmountGwei, address(registry));
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
         (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
         vm.deal(challenger, 100 ether);
@@ -250,7 +249,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         );
 
         _verifySlashCommitmentBalances(
-            challenger, slashAmountGwei * 1 gwei, rewardAmountGwei * 1 gwei, challengerBalanceBefore, urcBalanceBefore
+            challenger, slashAmountGwei * 1 gwei, 0, challengerBalanceBefore, urcBalanceBefore
         );
 
         // Retrieve operator data
@@ -260,11 +259,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");
 
         // Verify operator's collateralGwei is decremented
-        assertEq(
-            operatorData.collateralGwei,
-            collateral / 1 gwei - slashAmountGwei - rewardAmountGwei,
-            "collateralGwei not decremented"
-        );
+        assertEq(operatorData.collateralGwei, collateral / 1 gwei - slashAmountGwei, "collateralGwei not decremented");
 
         // Verify the slashedBefore mapping is set
         bytes32 slashingDigest =

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -59,7 +59,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -181,7 +181,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: alice,
+            owner: alice,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -164,7 +164,7 @@ contract RegistryTest is UnitTestHelper {
         _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0, 0);
     }
 
-    function test_slashRegistrationHeight1_DifferentWithdrawalAddress() public {
+    function test_slashRegistrationHeight1_DifferentOwner() public {
         (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
         uint256 collateral = 2 * minCollateral;
 
@@ -312,7 +312,7 @@ contract RegistryTest is UnitTestHelper {
         );
     }
 
-    function test_slashRegistrationHeight2_DifferentWithdrawalAddress() public {
+    function test_slashRegistrationHeight2_DifferentOwner() public {
         (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
         uint256 collateral = 2 * minCollateral;
 
@@ -473,7 +473,7 @@ contract RegistryTest is UnitTestHelper {
         }
     }
 
-    function test_slashRegistrationFuzz_DifferentWithdrawalAddress(uint8 n) public {
+    function test_slashRegistrationFuzz_DifferentOwner(uint8 n) public {
         vm.assume(n > 0);
         uint256 size = uint256(n);
         (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
@@ -605,7 +605,7 @@ contract RegistryTest is UnitTestHelper {
 
         // Verify registration was deleted
         IRegistry.Operator memory operatorData = getRegistrationData(registrationRoot);
-        assertEq(operatorData.withdrawalAddress, address(0), "Registration not deleted");
+        assertEq(operatorData.owner, address(0), "Registration not deleted");
     }
 
     function test_claimCollateral_notUnregistered() public {
@@ -751,7 +751,7 @@ contract RegistryTest is UnitTestHelper {
 
         // Verify registration was deleted
         IRegistry.Operator memory operatorData = getRegistrationData(reentrantContract.registrationRoot());
-        assertEq(operatorData.withdrawalAddress, address(0), "Registration not deleted");
+        assertEq(operatorData.owner, address(0), "Registration not deleted");
     }
 
     // For setup we register() -> slashRegistration()

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -45,12 +45,7 @@ contract RegistryTest is UnitTestHelper {
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         _assertRegistration(
-            registrationRoot,
-            operator,
-            uint56(collateral / 1 gwei),
-            uint32(block.number),
-            type(uint32).max,
-            0
+            registrationRoot, operator, uint56(collateral / 1 gwei), uint32(block.number), type(uint32).max, 0
         );
 
         // Attempt duplicate registration
@@ -68,12 +63,7 @@ contract RegistryTest is UnitTestHelper {
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         _assertRegistration(
-            registrationRoot,
-            operator,
-            uint56(collateral / 1 gwei),
-            uint32(block.number),
-            type(uint32).max,
-            0
+            registrationRoot, operator, uint56(collateral / 1 gwei), uint32(block.number), type(uint32).max, 0
         );
 
         // generate merkle proof
@@ -153,12 +143,7 @@ contract RegistryTest is UnitTestHelper {
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         _assertRegistration(
-            registrationRoot,
-            operator,
-            uint56(collateral / 1 gwei),
-            uint32(block.number),
-            type(uint32).max,
-            0
+            registrationRoot, operator, uint56(collateral / 1 gwei), uint32(block.number), type(uint32).max, 0
         );
 
         bytes32[] memory leaves = _hashToLeaves(registrations);
@@ -191,12 +176,7 @@ contract RegistryTest is UnitTestHelper {
 
         // Verify initial registration state
         _assertRegistration(
-            registrationRoot,
-            thief,
-            uint56(collateral / 1 gwei),
-            uint32(block.number),
-            type(uint32).max,
-            0
+            registrationRoot, thief, uint56(collateral / 1 gwei), uint32(block.number), type(uint32).max, 0
         );
 
         // Create proof for operator's registration
@@ -237,12 +217,7 @@ contract RegistryTest is UnitTestHelper {
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         _assertRegistration(
-            registrationRoot,
-            operator,
-            uint56(collateral / 1 gwei),
-            uint32(block.number),
-            type(uint32).max,
-            0
+            registrationRoot, operator, uint56(collateral / 1 gwei), uint32(block.number), type(uint32).max, 0
         );
 
         bytes32[] memory leaves = _hashToLeaves(registrations);
@@ -304,14 +279,7 @@ contract RegistryTest is UnitTestHelper {
             vm.startPrank(operator);
             registry.slashRegistration(registrationRoot, registrations[i], proof, i);
             _verifySlashingBalances(
-                operator,
-                thief,
-                0,
-                collateral,
-                collateral,
-                thiefBalanceBefore,
-                operatorBalanceBefore,
-                urcBalanceBefore
+                operator, thief, 0, collateral, collateral, thiefBalanceBefore, operatorBalanceBefore, urcBalanceBefore
             );
 
             _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
@@ -332,8 +300,7 @@ contract RegistryTest is UnitTestHelper {
     function test_unregister() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -350,8 +317,7 @@ contract RegistryTest is UnitTestHelper {
     function test_unregister_wrongOperator() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -364,8 +330,7 @@ contract RegistryTest is UnitTestHelper {
     function test_unregister_alreadyUnregistered() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -381,8 +346,7 @@ contract RegistryTest is UnitTestHelper {
     function test_claimCollateral() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -409,8 +373,7 @@ contract RegistryTest is UnitTestHelper {
     function test_claimCollateral_notUnregistered() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -423,8 +386,7 @@ contract RegistryTest is UnitTestHelper {
     function test_claimCollateral_delayNotMet() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -442,8 +404,7 @@ contract RegistryTest is UnitTestHelper {
     function test_claimCollateral_alreadyClaimed() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -465,8 +426,7 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = registry.MIN_COLLATERAL();
         vm.assume((addAmount + collateral) / 1 gwei < uint256(2 ** 56));
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -485,8 +445,7 @@ contract RegistryTest is UnitTestHelper {
     function test_addCollateral_overflow() public {
         uint256 collateral = registry.MIN_COLLATERAL();
 
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -421,7 +421,6 @@ contract ClaimCollateralTester is UnitTestHelper {
         vm.expectRevert(IRegistry.NoCollateralToClaim.selector);
         registry.claimCollateral(registrationRoot);
     }
-
 }
 
 contract AddCollateralTester is UnitTestHelper {

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -31,6 +31,8 @@ contract DummySlasherTest is UnitTestHelper {
     DummySlasher dummySlasher;
     BLS.G1Point delegatePubKey;
     uint256 collateral = 100 ether;
+    uint256 commitmentSecretKey;
+    address commitmentKey;
 
     function setUp() public {
         registry = new Registry();
@@ -38,6 +40,7 @@ contract DummySlasherTest is UnitTestHelper {
         vm.deal(operator, 100 ether);
         vm.deal(challenger, 100 ether);
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
+        (commitmentKey, commitmentSecretKey) = makeAddrAndKey("commitmentsKey");
     }
 
     function testDummySlasherUpdatesRegistry() public {
@@ -46,10 +49,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -118,10 +123,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -149,10 +156,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -175,10 +184,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -210,10 +221,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei - 1, // less than the slash amount
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -245,10 +258,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: address(rejectEther),
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -276,10 +291,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -367,10 +384,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
@@ -441,10 +460,12 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: address(0),
             delegateSecretKey: SECRET_KEY_2,
+            commitmentSecretKey: commitmentSecretKey,
+            commitmentKey: commitmentKey,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
-            validUntil: uint64(UINT256_MAX)
+            slot: uint64(UINT256_MAX)
         });
 
         (RegisterAndDelegateResult memory result,) = registerAndDelegateReentrant(params);

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -396,7 +396,7 @@ contract DummySlasherTest is UnitTestHelper {
         );
 
         // verify operator was deleted
-        _assertRegistration(result.registrationRoot, address(0), 0, 0, 0, 0, 0);
+        _assertRegistration(result.registrationRoot, address(0), 0, 0, 0, 0);
     }
 
     // test multiple slashings
@@ -795,7 +795,7 @@ contract DummySlasherTest is UnitTestHelper {
         registry.unregister(result.registrationRoot);
 
         // Move past unregistration delay
-        vm.roll(block.number + registry.MIN_UNREGISTRATION_DELAY() + 1);
+        vm.roll(block.number + registry.UNREGISTRATION_DELAY() + 1);
 
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.OperatorAlreadyUnregistered.selector);

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -33,8 +33,8 @@ contract DummySlasherTest is UnitTestHelper {
     DummySlasher dummySlasher;
     BLS.G1Point delegatePubKey;
     uint256 collateral = 100 ether;
-    uint256 commitmentSecretKey;
-    address commitmentKey;
+    uint256 committerSecretKey;
+    address committer;
 
     function setUp() public {
         registry = new Registry();
@@ -42,7 +42,7 @@ contract DummySlasherTest is UnitTestHelper {
         vm.deal(operator, 100 ether);
         vm.deal(challenger, 100 ether);
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
-        (commitmentKey, commitmentSecretKey) = makeAddrAndKey("commitmentsKey");
+        (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
     }
 
     function testDummySlasherUpdatesRegistry() public {
@@ -51,8 +51,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -62,7 +62,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
@@ -82,7 +82,7 @@ contract DummySlasherTest is UnitTestHelper {
             result.registrationRoot,
             dummySlasher.SLASH_AMOUNT_GWEI(),
             dummySlasher.REWARD_AMOUNT_GWEI(),
-            result.signedDelegation.delegation.proposerPubKey
+            result.signedDelegation.delegation.proposer
         );
 
         (uint256 gotSlashAmountGwei, uint256 gotRewardAmountGwei) = registry.slashCommitment(
@@ -131,8 +131,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -142,7 +142,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
         uint256 leafIndex = 0;
@@ -168,8 +168,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -178,7 +178,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Create invalid proof
         bytes32[] memory invalidProof = new bytes32[](1);
@@ -204,8 +204,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -215,7 +215,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Sign delegation with different secret key
         ISlasher.SignedDelegation memory badSignedDelegation =
@@ -245,8 +245,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei - 1, // less than the slash amount
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -255,7 +255,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
         uint256 leafIndex = 0;
@@ -285,8 +285,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: address(rejectEther),
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -295,7 +295,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
         uint256 leafIndex = 0;
@@ -321,8 +321,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -331,7 +331,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
@@ -379,7 +379,7 @@ contract DummySlasherTest is UnitTestHelper {
         );
 
         // attempt to slash with different SignedCommitment
-        signedCommitment = basicCommitment(params.commitmentSecretKey, params.slasher, "different payload");
+        signedCommitment = basicCommitment(params.committerSecretKey, params.slasher, "different payload");
         vm.expectRevert(IRegistry.SlashWindowExpired.selector);
         registry.slashCommitment(
             result.registrationRoot,
@@ -417,8 +417,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -427,7 +427,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
@@ -444,7 +444,7 @@ contract DummySlasherTest is UnitTestHelper {
             result.registrationRoot,
             dummySlasher.SLASH_AMOUNT_GWEI(),
             dummySlasher.REWARD_AMOUNT_GWEI(),
-            result.signedDelegation.delegation.proposerPubKey
+            result.signedDelegation.delegation.proposer
         );
         registry.slashCommitment(
             result.registrationRoot,
@@ -457,13 +457,13 @@ contract DummySlasherTest is UnitTestHelper {
         );
 
         // slash again with different SignedCommitment
-        signedCommitment = basicCommitment(params.commitmentSecretKey, params.slasher, "different payload");
+        signedCommitment = basicCommitment(params.committerSecretKey, params.slasher, "different payload");
         vm.expectEmit(address(registry));
         emit IRegistry.OperatorSlashed(
             result.registrationRoot,
             dummySlasher.SLASH_AMOUNT_GWEI(),
             dummySlasher.REWARD_AMOUNT_GWEI(),
-            result.signedDelegation.delegation.proposerPubKey
+            result.signedDelegation.delegation.proposer
         );
         registry.slashCommitment(
             result.registrationRoot,
@@ -491,8 +491,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -511,10 +511,9 @@ contract DummySlasherTest is UnitTestHelper {
 
         // Sign delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot,
             metadata: "different metadata"
         });
@@ -554,8 +553,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -569,10 +568,9 @@ contract DummySlasherTest is UnitTestHelper {
 
         // Create second delegation with different metadata
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot,
             metadata: "different metadata"
         });
@@ -598,8 +596,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -614,10 +612,9 @@ contract DummySlasherTest is UnitTestHelper {
 
         // Create second delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot,
             metadata: "different metadata"
         });
@@ -645,8 +642,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -678,8 +675,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -693,10 +690,9 @@ contract DummySlasherTest is UnitTestHelper {
 
         // Create second delegation with different slot
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot + 1, // Different slot
             metadata: "different metadata"
         });
@@ -724,8 +720,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -739,10 +735,9 @@ contract DummySlasherTest is UnitTestHelper {
 
         // Create second delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot,
             metadata: "different metadata"
         });
@@ -792,8 +787,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -807,10 +802,9 @@ contract DummySlasherTest is UnitTestHelper {
 
         // Create second delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot,
             metadata: "different metadata"
         });
@@ -850,8 +844,8 @@ contract DummySlasherTest is UnitTestHelper {
             collateral: collateral,
             withdrawalAddress: address(0),
             delegateSecretKey: SECRET_KEY_2,
-            commitmentSecretKey: commitmentSecretKey,
-            commitmentKey: commitmentKey,
+            committerSecretKey: committerSecretKey,
+            committer: committer,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
@@ -860,7 +854,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         (RegisterAndDelegateResult memory result,) = registerAndDelegateReentrant(params);
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
@@ -881,7 +875,7 @@ contract DummySlasherTest is UnitTestHelper {
             result.registrationRoot,
             dummySlasher.SLASH_AMOUNT_GWEI(),
             dummySlasher.REWARD_AMOUNT_GWEI(),
-            result.signedDelegation.delegation.proposerPubKey
+            result.signedDelegation.delegation.proposer
         );
         (uint256 gotSlashAmountGwei, uint256 gotRewardAmountGwei) = registry.slashCommitment(
             result.registrationRoot,

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -494,8 +494,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
             dummySlasher.SLASH_AMOUNT_GWEI()
         );
 
-        uint256 gotSlashAmountGwei =
-            registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        uint256 gotSlashAmountGwei = registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
 
         assertEq(dummySlasher.SLASH_AMOUNT_GWEI(), gotSlashAmountGwei, "Slash amount incorrect");
 
@@ -547,7 +546,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash before fraud proof window expires
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.FraudProofWindowNotMet.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertOperatorAlreadyUnregistered() public {
@@ -585,7 +584,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash after unregistration delay
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.OperatorAlreadyUnregistered.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertSlashWindowExpired() public {
@@ -615,7 +614,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
 
         // First slash
         vm.startPrank(challenger);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
 
         // Wait for slash window to expire
         vm.roll(block.number + registry.SLASH_WINDOW() + 1);
@@ -623,7 +622,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash again after window expired
         signedCommitment = basicCommitment(params.committerSecretKey, params.slasher, "different payload");
         vm.expectRevert(IRegistry.SlashWindowExpired.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertNotOptedIn() public {
@@ -650,7 +649,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash without opting in
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.NotOptedIn.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertUnauthorizedCommitment() public {
@@ -682,7 +681,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash with unauthorized commitment
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.UnauthorizedCommitment.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertSlashAmountExceedsCollateral() public {
@@ -713,7 +712,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash with amount exceeding collateral
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.SlashAmountExceedsCollateral.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, address(dummySlasher), signedCommitment, "");
+        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
     }
 }
 

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -45,7 +45,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -124,7 +124,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -160,7 +160,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -195,7 +195,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -235,7 +235,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei - 1, // less than the slash amount
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -274,7 +274,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: address(rejectEther),
+            owner: address(rejectEther),
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -309,7 +309,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -404,7 +404,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -477,7 +477,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -537,7 +537,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -578,7 +578,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -622,7 +622,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -654,7 +654,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -697,7 +697,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -762,7 +762,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,
@@ -817,7 +817,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: address(0),
+            owner: address(0),
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -14,10 +14,6 @@ contract DummySlasher is ISlasher {
     uint256 public SLASH_AMOUNT_GWEI = 1 ether / 1 gwei;
     uint256 public REWARD_AMOUNT_GWEI = 0.1 ether / 1 gwei; // MIN_COLLATERAL
 
-    function DOMAIN_SEPARATOR() external view returns (bytes memory) {
-        return bytes("DUMMY-SLASHER-DOMAIN-SEPARATOR");
-    }
-
     function slash(
         ISlasher.Delegation calldata delegation,
         ISlasher.Commitment calldata commitment,
@@ -54,7 +50,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: 0
         });
@@ -134,7 +129,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -171,7 +165,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -207,7 +200,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -219,7 +211,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         // Sign delegation with different secret key
         ISlasher.SignedDelegation memory badSignedDelegation =
-            signDelegation(SECRET_KEY_2, result.signedDelegation.delegation, params.domainSeparator);
+            signDelegation(SECRET_KEY_2, result.signedDelegation.delegation);
 
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
         uint256 leafIndex = 0;
@@ -248,7 +240,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -288,7 +279,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -324,7 +314,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -420,7 +409,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -494,7 +482,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -518,8 +505,7 @@ contract DummySlasherTest is UnitTestHelper {
             metadata: "different metadata"
         });
 
-        ISlasher.SignedDelegation memory signedDelegationTwo =
-            signDelegation(params.proposerSecretKey, delegationTwo, params.domainSeparator);
+        ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
 
         // submit both delegations
         uint256 challengerBalanceBefore = challenger.balance;
@@ -556,7 +542,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -575,8 +560,7 @@ contract DummySlasherTest is UnitTestHelper {
             metadata: "different metadata"
         });
 
-        ISlasher.SignedDelegation memory signedDelegationTwo =
-            signDelegation(params.proposerSecretKey, delegationTwo, params.domainSeparator);
+        ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
 
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.FraudProofWindowNotMet.selector);
@@ -599,7 +583,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -619,8 +602,7 @@ contract DummySlasherTest is UnitTestHelper {
             metadata: "different metadata"
         });
 
-        ISlasher.SignedDelegation memory signedDelegationTwo =
-            signDelegation(params.proposerSecretKey, delegationTwo, params.domainSeparator);
+        ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
 
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
@@ -645,7 +627,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -678,7 +659,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: 1000
         });
@@ -697,8 +677,7 @@ contract DummySlasherTest is UnitTestHelper {
             metadata: "different metadata"
         });
 
-        ISlasher.SignedDelegation memory signedDelegationTwo =
-            signDelegation(params.proposerSecretKey, delegationTwo, params.domainSeparator);
+        ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
 
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
@@ -723,7 +702,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -742,8 +720,7 @@ contract DummySlasherTest is UnitTestHelper {
             metadata: "different metadata"
         });
 
-        ISlasher.SignedDelegation memory signedDelegationTwo =
-            signDelegation(params.proposerSecretKey, delegationTwo, params.domainSeparator);
+        ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
 
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
@@ -790,7 +767,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });
@@ -809,8 +785,7 @@ contract DummySlasherTest is UnitTestHelper {
             metadata: "different metadata"
         });
 
-        ISlasher.SignedDelegation memory signedDelegationTwo =
-            signDelegation(params.proposerSecretKey, delegationTwo, params.domainSeparator);
+        ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
 
         // move past the fraud proof window
         vm.roll(block.number + registry.FRAUD_PROOF_WINDOW() + 1);
@@ -847,7 +822,6 @@ contract DummySlasherTest is UnitTestHelper {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(dummySlasher),
-            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             slot: uint64(UINT256_MAX)
         });

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -521,34 +521,6 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         assertEq(slasherCommitment.optedOutAt, 0, "SlasherCommitment not cleared");
     }
 
-    function testRevertFraudProofWindowNotMet() public {
-        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
-            proposerSecretKey: SECRET_KEY_1,
-            collateral: collateral,
-            owner: operator,
-            delegateSecretKey: SECRET_KEY_2,
-            committerSecretKey: committerSecretKey,
-            committer: committer,
-            slasher: address(dummySlasher),
-            metadata: "",
-            slot: 0
-        });
-
-        RegisterAndDelegateResult memory result = registerAndDelegate(params);
-
-        ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.committerSecretKey, params.slasher, "");
-
-        // Opt in to slasher
-        vm.startPrank(operator);
-        registry.optInToSlasher(result.registrationRoot, address(dummySlasher), committer);
-
-        // Try to slash before fraud proof window expires
-        vm.startPrank(challenger);
-        vm.expectRevert(IRegistry.FraudProofWindowNotMet.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
-    }
-
     function testRevertOperatorAlreadyUnregistered() public {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
@@ -566,6 +538,9 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
 
         ISlasher.SignedCommitment memory signedCommitment =
             basicCommitment(params.committerSecretKey, params.slasher, "");
+
+        // skip past fraud proof window
+        vm.roll(block.number + registry.FRAUD_PROOF_WINDOW() + 1);
 
         // Opt in to slasher
         vm.startPrank(operator);
@@ -604,6 +579,9 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
 
         ISlasher.SignedCommitment memory signedCommitment =
             basicCommitment(params.committerSecretKey, params.slasher, "");
+
+        // skip past fraud proof window
+        vm.roll(block.number + registry.FRAUD_PROOF_WINDOW() + 1);
 
         // Opt in to slasher
         vm.startPrank(operator);
@@ -671,6 +649,9 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         (address wrongCommitter, uint256 wrongCommitterKey) = makeAddrAndKey("wrongCommitter");
         ISlasher.SignedCommitment memory signedCommitment = basicCommitment(wrongCommitterKey, params.slasher, "");
 
+        // skip past fraud proof window
+        vm.roll(block.number + registry.FRAUD_PROOF_WINDOW() + 1);
+
         // Opt in to slasher
         vm.startPrank(operator);
         registry.optInToSlasher(result.registrationRoot, address(dummySlasher), committer);
@@ -701,6 +682,9 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
 
         ISlasher.SignedCommitment memory signedCommitment =
             basicCommitment(params.committerSecretKey, params.slasher, "");
+
+        // skip past fraud proof window
+        vm.roll(block.number + registry.FRAUD_PROOF_WINDOW() + 1);
 
         // Opt in to slasher
         vm.startPrank(operator);

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -120,7 +120,6 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
             committerSecretKey: committerSecretKey,
             committer: committer,
             slasher: address(slasher),
-            domainSeparator: slasher.DOMAIN_SEPARATOR(),
             metadata: metadata,
             slot: slot
         });
@@ -141,9 +140,6 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         // Create new keypair and fund wallet
         (address alice, uint256 alicePK) = makeAddrAndKey(string.concat("alice_", vm.toString(id)));
         vm.deal(alice, 100 ether); // Give alice some ETH
-
-        // Create ecdsa keypair for delegate
-        (address delegate, uint256 delegatePK) = makeAddrAndKey("delegate");
 
         // Advance before the fraud proof window
         vm.roll(exclusionBlockNumber - registry.FRAUD_PROOF_WINDOW());
@@ -206,7 +202,6 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
 
         // Save for comparison after slashing
         uint256 challengerBalanceBefore = challenger.balance;
-        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
         // Slash via URC

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -15,13 +15,14 @@ import { SecureMerkleTrie } from "../example/lib/trie/SecureMerkleTrie.sol";
 import { TransactionDecoder } from "../example/lib/TransactionDecoder.sol";
 import { Registry } from "../src/Registry.sol";
 import { IRegistry } from "../src/IRegistry.sol";
+import { ISlasher } from "../src/ISlasher.sol";
 import { BLS } from "../src/lib/BLS.sol";
 import { MerkleTree } from "../src/lib/MerkleTree.sol";
 import { PreconfStructs } from "../example/PreconfStructs.sol";
 import { StateLockSlasher } from "../example/StateLockSlasher.sol";
 import { UnitTestHelper } from "./UnitTestHelper.sol";
 
-contract StateLockSlasherTest is UnitTestHelper {
+contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
     using RLPReader for bytes;
     using RLPReader for RLPReader.RLPItem;
     using BytesUtils for bytes;
@@ -103,7 +104,7 @@ contract StateLockSlasherTest is UnitTestHelper {
         vm.pauseGasMetering();
     }
 
-    function setupRegistration(address operator, address delegate)
+    function setupRegistration(address operator, address delegate, uint64 slot)
         internal
         returns (RegisterAndDelegateResult memory result)
     {
@@ -121,14 +122,21 @@ contract StateLockSlasherTest is UnitTestHelper {
             slasher: address(slasher),
             domainSeparator: slasher.DOMAIN_SEPARATOR(),
             metadata: metadata,
-            slot: uint64(UINT256_MAX)
+            slot: slot
         });
 
         // Register operator to URC and signs delegation message
         result = registerAndDelegate(params);
     }
 
-    function setupSlash(uint256 id) public returns (RegisterAndDelegateResult memory result, bytes memory evidence) {
+    function setupSlash(uint256 id)
+        public
+        returns (
+            RegisterAndDelegateResult memory result,
+            ISlasher.SignedCommitment memory signedCommitment,
+            bytes memory evidence
+        )
+    {
         uint256 exclusionBlockNumber = 20_785_012;
         // Create new keypair and fund wallet
         (address alice, uint256 alicePK) = makeAddrAndKey(string.concat("alice_", vm.toString(id)));
@@ -142,15 +150,16 @@ contract StateLockSlasherTest is UnitTestHelper {
         vm.warp(exclusionBlockNumber - registry.FRAUD_PROOF_WINDOW() * 12);
 
         // Register and delegate
-        result = setupRegistration(alice, delegate);
+        result = setupRegistration(alice, delegate, 9994114 - 100);
 
         // Advance over registration fraud proof window to the target slot
         vm.roll(exclusionBlockNumber);
         vm.warp(slasher._getTimestampFromSlot(9994114)); // https://etherscan.io/block/20785012
 
+        // Register and delegate
         // Delegate signs a commitment to exclude a TX
-        PreconfStructs.SignedCommitmentTemp memory commitment =
-            _createStateLockCommitment(exclusionBlockNumber, id, delegate, delegatePK);
+        TransactionCommitment memory commitment =
+            _createStateLockCommitment(exclusionBlockNumber, id, commitmentKey, commitmentSecretKey);
 
         // Build the inclusion proof to prove failure to exclude
         string memory rawPreviousHeader = vm.readFile("./test/testdata/header_20785011.json");
@@ -164,7 +173,7 @@ contract StateLockSlasherTest is UnitTestHelper {
         uint256[] memory txIndexesInBlock = new uint256[](1);
         txIndexesInBlock[0] = vm.parseJsonUint(txProof, ".index");
 
-        PreconfStructs.InclusionProof memory inclusionProof = PreconfStructs.InclusionProof({
+        InclusionProof memory inclusionProof = InclusionProof({
             inclusionBlockNumber: exclusionBlockNumber,
             previousBlockHeaderRLP: vm.parseJsonBytes(rawPreviousHeader, ".result"),
             inclusionBlockHeaderRLP: vm.parseJsonBytes(rawInclusionHeader, ".result"),
@@ -177,12 +186,18 @@ contract StateLockSlasherTest is UnitTestHelper {
         bytes32 inclusionTxRoot = slasher._decodeBlockHeaderRLP(inclusionProof.inclusionBlockHeaderRLP).txRoot;
         assertEq(inclusionTxRoot, vm.parseJsonBytes32(txProof, ".root"));
 
-        evidence = abi.encode(commitment, inclusionProof);
+        signedCommitment = basicCommitment(commitmentSecretKey, address(slasher), abi.encode(commitment));
+
+        evidence = abi.encode(inclusionProof);
     }
 
     function test_slash() public {
         // Register at URC and generate slashable evidence
-        (RegisterAndDelegateResult memory result, bytes memory evidence) = setupSlash(1);
+        (
+            RegisterAndDelegateResult memory result,
+            ISlasher.SignedCommitment memory signedCommitment,
+            bytes memory evidence
+        ) = setupSlash(1);
 
         // Merkle proof for URC registration
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
@@ -202,6 +217,7 @@ contract StateLockSlasherTest is UnitTestHelper {
             registrationProof,
             leafIndex,
             result.signedDelegation,
+            signedCommitment,
             evidence
         );
 
@@ -223,7 +239,8 @@ contract StateLockSlasherTest is UnitTestHelper {
         );
 
         // Verify the slashedBefore mapping is set
-        bytes32 slashingDigest = keccak256(abi.encode(result.signedDelegation, result.registrationRoot));
+        bytes32 slashingDigest =
+            keccak256(abi.encode(result.signedDelegation, signedCommitment, result.registrationRoot));
         assertEq(registry.slashedBefore(slashingDigest), true, "slashedBefore not set");
     }
 
@@ -233,7 +250,7 @@ contract StateLockSlasherTest is UnitTestHelper {
     function _createStateLockCommitment(uint256 blockNumber, uint256 id, address delegate, uint256 delegatePK)
         internal
         view
-        returns (PreconfStructs.SignedCommitmentTemp memory commitment)
+        returns (TransactionCommitment memory commitment)
     {
         // pattern: ./test/testdata/signed_tx_{blockNumber}_{id}.json
         string memory base = "./test/testdata/signed_tx_";

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -115,7 +115,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: operator,
+            owner: operator,
             delegateSecretKey: SECRET_KEY_2,
             committerSecretKey: committerSecretKey,
             committer: committer,

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -220,7 +220,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         );
 
         // Retrieve operator data
-        IRegistry.Operator memory operatorData = getRegistrationData(result.registrationRoot);
+        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -32,14 +32,13 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
     StateLockSlasher slasher;
     BLS.G1Point delegatePubKey;
     uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
-    uint256 rewardAmountGwei = 0.1 ether / 1 gwei; // reward 0.1 ether
     uint256 collateral = 1.1 ether;
     uint256 committerSecretKey;
     address committer;
 
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
-        slasher = new StateLockSlasher(slashAmountGwei, rewardAmountGwei);
+        slasher = new StateLockSlasher(slashAmountGwei);
         registry = new Registry();
         (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
@@ -217,7 +216,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         );
 
         _verifySlashCommitmentBalances(
-            challenger, slashAmountGwei * 1 gwei, rewardAmountGwei * 1 gwei, challengerBalanceBefore, urcBalanceBefore
+            challenger, slashAmountGwei * 1 gwei, 0, challengerBalanceBefore, urcBalanceBefore
         );
 
         // Retrieve operator data
@@ -227,11 +226,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");
 
         // Verify operator's collateralGwei is decremented
-        assertEq(
-            operatorData.collateralGwei,
-            collateral / 1 gwei - slashAmountGwei - rewardAmountGwei,
-            "collateralGwei not decremented"
-        );
+        assertEq(operatorData.collateralGwei, collateral / 1 gwei - slashAmountGwei, "collateralGwei not decremented");
 
         // Verify the slashedBefore mapping is set
         bytes32 slashingDigest =

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -183,8 +183,8 @@ contract UnitTestHelper is Test {
         uint256 collateral;
         address withdrawalAddress;
         uint256 delegateSecretKey;
-        uint256 commitmentSecretKey;
-        address commitmentKey;
+        uint256 committerSecretKey;
+        address committer;
         address slasher;
         bytes domainSeparator;
         bytes metadata;
@@ -207,10 +207,9 @@ contract UnitTestHelper is Test {
 
         // Sign delegation
         ISlasher.Delegation memory delegation = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot,
             metadata: params.metadata
         });
@@ -235,10 +234,9 @@ contract UnitTestHelper is Test {
 
         // Sign delegation
         ISlasher.Delegation memory delegation = ISlasher.Delegation({
-            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
-            commitmentsKey: params.commitmentKey,
-            slasher: params.slasher,
+            proposer: BLS.toPublicKey(params.proposerSecretKey),
+            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            committer: params.committer,
             slot: params.slot,
             metadata: params.metadata
         });
@@ -246,7 +244,7 @@ contract UnitTestHelper is Test {
         result.signedDelegation = signDelegation(params.proposerSecretKey, delegation, params.domainSeparator);
 
         ISlasher.SignedCommitment memory signedCommitment =
-            basicCommitment(params.commitmentSecretKey, params.slasher, "");
+            basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // save info for later reentrancy
         reentrantContract.saveResult(params, result, signedCommitment);

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -21,11 +21,7 @@ contract UnitTestHelper is Test {
     uint256 constant SECRET_KEY_2 = 67890;
 
     /// @dev Helper to create a BLS signature for a registration
-    function _registrationSignature(uint256 secretKey, address owner)
-        internal
-        view
-        returns (BLS.G2Point memory)
-    {
+    function _registrationSignature(uint256 secretKey, address owner) internal view returns (BLS.G2Point memory) {
         bytes memory message = abi.encode(owner);
         return BLS.sign(message, secretKey, registry.DOMAIN_SEPARATOR());
     }
@@ -108,13 +104,8 @@ contract UnitTestHelper is Test {
     }
 
     function getRegistrationData(bytes32 registrationRoot) public view returns (IRegistry.Operator memory) {
-        (
-            address owner,
-            uint56 collateralGwei,
-            uint32 registeredAt,
-            uint32 unregisteredAt,
-            uint32 slashedAt
-        ) = registry.registrations(registrationRoot);
+        (address owner, uint56 collateralGwei, uint32 registeredAt, uint32 unregisteredAt, uint32 slashedAt) =
+            registry.registrations(registrationRoot);
 
         return IRegistry.Operator({
             owner: owner,
@@ -134,12 +125,7 @@ contract UnitTestHelper is Test {
         registrationRoot = registry.register{ value: collateral }(registrations, owner);
 
         _assertRegistration(
-            registrationRoot,
-            owner,
-            uint56(collateral / 1 gwei),
-            uint32(block.number),
-            type(uint32).max,
-            0
+            registrationRoot, owner, uint56(collateral / 1 gwei), uint32(block.number), type(uint32).max, 0
         );
     }
 

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -47,7 +47,7 @@ contract UnitTestHelper is Test {
         uint32 expectedUnregisteredAt,
         uint32 expectedSlashedAt
     ) internal view {
-        IRegistry.Operator memory operatorData = getRegistrationData(registrationRoot);
+        OperatorData memory operatorData = getRegistrationData(registrationRoot);
         assertEq(operatorData.owner, expectedowner, "Wrong withdrawal address");
         assertEq(operatorData.collateralGwei, expectedCollateral, "Wrong collateral amount");
         assertEq(operatorData.registeredAt, expectedRegisteredAt, "Wrong registration block");
@@ -103,7 +103,16 @@ contract UnitTestHelper is Test {
         assertEq(address(registry).balance, _urcBalanceBefore - _slashedAmount - _rewardAmount, "urc balance incorrect");
     }
 
-    function getRegistrationData(bytes32 registrationRoot) public view returns (IRegistry.Operator memory) {
+    struct OperatorData {
+        address owner;
+        uint56 collateralGwei;
+        uint8 numKeys;
+        uint32 registeredAt;
+        uint32 unregisteredAt;
+        uint32 slashedAt;
+    }
+
+    function getRegistrationData(bytes32 registrationRoot) public view returns (OperatorData memory) {
         (
             address owner,
             uint56 collateralGwei,
@@ -113,7 +122,7 @@ contract UnitTestHelper is Test {
             uint32 slashedAt
         ) = registry.registrations(registrationRoot);
 
-        return IRegistry.Operator({
+        return OperatorData({
             owner: owner,
             collateralGwei: collateralGwei,
             numKeys: numKeys,

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -170,10 +170,12 @@ contract UnitTestHelper is Test {
         uint256 collateral;
         address withdrawalAddress;
         uint256 delegateSecretKey;
+        uint256 commitmentSecretKey;
+        address commitmentKey;
         address slasher;
         bytes domainSeparator;
         bytes metadata;
-        uint64 validUntil;
+        uint64 slot;
     }
 
     struct RegisterAndDelegateResult {
@@ -193,9 +195,10 @@ contract UnitTestHelper is Test {
         // Sign delegation
         ISlasher.Delegation memory delegation = ISlasher.Delegation({
             proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            delegatePubKey: BLS.toPublicKey(params.delegateSecretKey),
+            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
+            commitmentsKey: params.commitmentKey,
             slasher: params.slasher,
-            validUntil: params.validUntil,
+            slot: params.slot,
             metadata: params.metadata
         });
 
@@ -220,9 +223,10 @@ contract UnitTestHelper is Test {
         // Sign delegation
         ISlasher.Delegation memory delegation = ISlasher.Delegation({
             proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
-            delegatePubKey: BLS.toPublicKey(params.delegateSecretKey),
+            constraintsKey: BLS.toPublicKey(params.delegateSecretKey),
+            commitmentsKey: params.commitmentKey,
             slasher: params.slasher,
-            validUntil: params.validUntil,
+            slot: params.slot,
             metadata: params.metadata
         });
 

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -104,12 +104,19 @@ contract UnitTestHelper is Test {
     }
 
     function getRegistrationData(bytes32 registrationRoot) public view returns (IRegistry.Operator memory) {
-        (address owner, uint56 collateralGwei, uint32 registeredAt, uint32 unregisteredAt, uint32 slashedAt) =
-            registry.registrations(registrationRoot);
+        (
+            address owner,
+            uint56 collateralGwei,
+            uint8 numKeys,
+            uint32 registeredAt,
+            uint32 unregisteredAt,
+            uint32 slashedAt
+        ) = registry.registrations(registrationRoot);
 
         return IRegistry.Operator({
             owner: owner,
             collateralGwei: collateralGwei,
+            numKeys: numKeys,
             registeredAt: registeredAt,
             unregisteredAt: unregisteredAt,
             slashedAt: slashedAt


### PR DESCRIPTION
Modifies the ISlasher interface and slashing logic as described [here](https://twisty-wednesday-4be.notion.site/Paths-forward-for-the-URC-18c968886c718080a73ee2d12145df08?pvs=4). 

### Changelog
- Introduce `Commitment` struct and modify the Delegation struct to include a `commitmentsKey` address for issuing commitments, replace `validUntil` -> `slot`, and remove the `slasher` address. The idea is that `Delegation` messages are no longer how you commit to Slasher contracts - instead `Commitment` messages are signed via the `committer` address' ECDSA key. 
- Modify `slashCommitment()` and `ISlasher` interface to accommodate these changes. 

- Add `slashEquivocation()` which slashes an operator if they've signed multiple `Delegation` messages for the same slot number.

- Remove `DOMAIN_SEPARATOR()` from Slasher interface as `Delegation` messagses can be signed with a central domain seperator defined as `URC.DELEGATION_DOMAIN_SEPARATOR`

- Remove `unregistrationDelay` from `Operator` struct to remove edge cases and make a simpler operator UX.

- Add `numKeys` field to `Operator` struct to make lives easier for protocols consuming URC.

- Add a mapping to track which Slasher contracts the operator has opted in to (on-chain). This requires adding `optInToSlasher()`, `optOutOfSlasher()`, and `slashCommitmentFromOptIns()` to `Registry.sol` to handle slashing without `Delegation` messages. Similarly the `ISlasher` interface added `slashFromOptIn()`. 

- Modified slashing rewards. Now only `slashRegistration()` and `slashEquivocation()` pay the challenger. The `slashCommitment()` and `slashCommitmentFromOptIns()` functions strictly burn eth. This addresses edge cases where adversarial operators could self-slash to reclaim their collateral which undermines the credibility of the commitments they make.

This PR is related to [this PR in the Constraints API](https://github.com/eth-fabric/constraints-specs/pull/18 ). 