### PR TITLE
Optimizations

### DIFF
--- a/example/InclusionPreconfSlasher.sol
+++ b/example/InclusionPreconfSlasher.sol
@@ -22,7 +22,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
     using TransactionDecoder for TransactionDecoder.Transaction;
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
-    uint256 public SLASH_AMOUNT_GWEI;
+    uint256 public SLASH_AMOUNT_WEI;
     address public constant BEACON_ROOTS_CONTRACT =
         0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
     uint256 public constant EIP4788_WINDOW = 8191;
@@ -35,8 +35,8 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
     address public urc;
     mapping(bytes32 challengeID => Challenge challenge) public challenges;
 
-    constructor(uint256 _slashAmountGwei, address _urc) {
-        SLASH_AMOUNT_GWEI = _slashAmountGwei;
+    constructor(uint256 _slashAmountWei, address _urc) {
+        SLASH_AMOUNT_WEI = _slashAmountWei;
         urc = _urc;
 
         if (block.chainid == 17000) {
@@ -125,7 +125,7 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
         ISlasher.Commitment calldata commitment,
         bytes calldata evidence,
         address challenger
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountWei) {
         if (msg.sender != urc) {
             revert NotURC();
         }
@@ -153,14 +153,14 @@ contract InclusionPreconfSlasher is ISlasher, PreconfStructs {
         }
 
         // Return the slash amount to the URC slasher
-        slashAmountGwei = SLASH_AMOUNT_GWEI;
+        slashAmountWei = SLASH_AMOUNT_WEI;
     }
 
     function slashFromOptIn(
         ISlasher.Commitment calldata commitment,
         bytes calldata evidence,
         address challenger
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountWei) {
         // unused in this example
     }
 

--- a/example/StateLockSlasher.sol
+++ b/example/StateLockSlasher.sol
@@ -22,7 +22,7 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
     using TransactionDecoder for TransactionDecoder.Transaction;
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
-    uint256 public SLASH_AMOUNT_GWEI;
+    uint256 public SLASH_AMOUNT_WEI;
     address public constant BEACON_ROOTS_CONTRACT =
         0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
     uint256 public constant EIP4788_WINDOW = 8191;
@@ -31,8 +31,8 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
     uint256 public constant SLOT_TIME = 12;
     uint256 public ETH2_GENESIS_TIMESTAMP;
 
-    constructor(uint256 _slashAmountGwei) {
-        SLASH_AMOUNT_GWEI = _slashAmountGwei;
+    constructor(uint256 _slashAmountWei) {
+        SLASH_AMOUNT_WEI = _slashAmountWei;
 
         if (block.chainid == 17000) {
             // Holesky
@@ -51,7 +51,7 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
         ISlasher.Commitment calldata commitment,
         bytes calldata evidence,
         address challenger
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountWei) {
         // Recover the slashing evidence
         // commitment: signature to EXCLUDE a tx
         // proof: MPT inclusion proof
@@ -74,14 +74,14 @@ contract StateLockSlasher is ISlasher, PreconfStructs {
         _verifyInclusionProof(txCommitment, proof, delegation.committer);
 
         // Return the slash amount to the URC slasher
-        slashAmountGwei = SLASH_AMOUNT_GWEI;
+        slashAmountWei = SLASH_AMOUNT_WEI;
     }
 
     function slashFromOptIn(
         ISlasher.Commitment calldata commitment,
         bytes calldata evidence,
         address challenger
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountWei) {
         // unused in this example
     }
 

--- a/script/Registry.s.sol
+++ b/script/Registry.s.sol
@@ -13,8 +13,16 @@ contract RegistryScript is Script {
         // Start broadcasting transactions
         vm.startBroadcast(deployerPrivateKey);
 
+        IRegistry.Config memory config = IRegistry.Config({
+            minCollateralWei: 0.1 ether,
+            fraudProofWindow: 7200,
+            unregistrationDelay: 7200,
+            slashWindow: 7200,
+            optInDelay: 7200
+        });
+
         // Deploy the Registry contract
-        Registry registry = new Registry();
+        Registry registry = new Registry(config);
 
         // Log the deployed address
         console.log("Registry deployed to:", address(registry));

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -76,12 +76,6 @@ interface IRegistry {
     /// @param owner The owner of the operator
     event OperatorRegistered(bytes32 indexed registrationRoot, uint256 collateralGwei, address owner);
 
-    /// @notice Emitted when a BLS key is registered
-    /// @param leafIndex The index of the BLS key in the registration merkle tree
-    /// @param reg The registration
-    /// @param leaf The leaf hash value of the `Registration`
-    event KeyRegistered(uint256 leafIndex, Registration reg, bytes32 leaf);
-
     /// @notice Emitted when an operator is slashed for fraud, equivocation, or breaking a commitment
     /// @param registrationRoot The merkle root of the registration merkle tree
     /// @param owner The owner of the operator

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -25,16 +25,16 @@ interface IRegistry {
     struct Operator {
         /// The authorized address of the operator
         address owner;
-        /// ETH collateral in GWEI
-        uint56 collateralGwei;
-        /// The number of keys registered per operator (capped at 255)
-        uint8 numKeys;
+        /// ETH collateral in WEI
+        uint80 collateralWei;
+        /// The number of keys registered per operator
+        uint16 numKeys;
         /// The block number when registration occurred
-        uint32 registeredAt;
+        uint48 registeredAt;
         /// The block number when deregistration occurred
-        uint32 unregisteredAt;
+        uint48 unregisteredAt;
         /// The block number when slashed from breaking a commitment
-        uint32 slashedAt;
+        uint48 slashedAt;
         /// Mapping to track opt-in and opt-out status for proposer commitment protocols
         mapping(address slasher => SlasherCommitment) slasherCommitments;
         /// Historical collateral records
@@ -54,7 +54,7 @@ interface IRegistry {
     /// @notice A record of collateral at a specific timestamp
     struct CollateralRecord {
         uint64 timestamp;
-        uint56 collateralValue;
+        uint80 collateralValue;
     }
 
     enum SlashingType {
@@ -72,9 +72,9 @@ interface IRegistry {
      */
     /// @notice Emitted when an operator is registered
     /// @param registrationRoot The merkle root of the registration merkle tree
-    /// @param collateralGwei The collateral amount in GWEI
+    /// @param collateralWei The collateral amount in WEI
     /// @param owner The owner of the operator
-    event OperatorRegistered(bytes32 indexed registrationRoot, uint256 collateralGwei, address owner);
+    event OperatorRegistered(bytes32 indexed registrationRoot, uint256 collateralWei, address owner);
 
     /// @notice Emitted when an operator is slashed for fraud, equivocation, or breaking a commitment
     /// @param registrationRoot The merkle root of the registration merkle tree
@@ -82,30 +82,30 @@ interface IRegistry {
     /// @param challenger The address of the challenger
     /// @param slashingType The type of slashing
     /// @param slasher The address of the slasher
-    /// @param slashAmountGwei The amount of GWEI slashed
+    /// @param slashAmountWei The amount of WEI slashed
     event OperatorSlashed(
         SlashingType slashingType,
         bytes32 indexed registrationRoot,
         address owner,
         address challenger,
         address indexed slasher,
-        uint256 slashAmountGwei
+        uint256 slashAmountWei
     );
 
     /// @notice Emitted when an operator is unregistered
     /// @param registrationRoot The merkle root of the registration merkle tree
     /// @param unregisteredAt The block number when the operator was unregistered
-    event OperatorUnregistered(bytes32 indexed registrationRoot, uint32 unregisteredAt);
+    event OperatorUnregistered(bytes32 indexed registrationRoot, uint48 unregisteredAt);
 
     /// @notice Emitted when collateral is claimed
     /// @param registrationRoot The merkle root of the registration merkle tree
-    /// @param collateralGwei The amount of GWEI claimed
-    event CollateralClaimed(bytes32 indexed registrationRoot, uint256 collateralGwei);
+    /// @param collateralWei The amount of WEI claimed
+    event CollateralClaimed(bytes32 indexed registrationRoot, uint256 collateralWei);
 
     /// @notice Emitted when collateral is added
     /// @param registrationRoot The merkle root of the registration merkle tree
-    /// @param collateralGwei The amount of GWEI added
-    event CollateralAdded(bytes32 indexed registrationRoot, uint256 collateralGwei);
+    /// @param collateralWei The amount of WEI added
+    event CollateralAdded(bytes32 indexed registrationRoot, uint256 collateralWei);
 
     /// @notice Emitted when an operator is opted into a proposer commitment protocol
     /// @param registrationRoot The merkle root of the registration merkle tree
@@ -179,7 +179,7 @@ interface IRegistry {
         Registration calldata reg,
         bytes32[] calldata proof,
         uint256 leafIndex
-    ) external returns (uint256 collateral);
+    ) external returns (uint256 collateralWei);
 
     function slashCommitment(
         bytes32 registrationRoot,
@@ -189,13 +189,13 @@ interface IRegistry {
         ISlasher.SignedDelegation calldata delegation,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei);
+    ) external returns (uint256 slashAmountWei);
 
     function slashCommitmentFromOptIn(
         bytes32 registrationRoot,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei);
+    ) external returns (uint256 slashAmountWei);
 
     function slashEquivocation(
         bytes32 registrationRoot,
@@ -204,7 +204,7 @@ interface IRegistry {
         uint256 leafIndex,
         ISlasher.SignedDelegation calldata delegationOne,
         ISlasher.SignedDelegation calldata delegationTwo
-    ) external returns (uint256 slashAmountGwei);
+    ) external returns (uint256 slashAmountWei);
 
     function addCollateral(bytes32 registrationRoot) external payable;
 
@@ -215,7 +215,7 @@ interface IRegistry {
     function verifyMerkleProof(bytes32 registrationRoot, bytes32 leaf, bytes32[] calldata proof, uint256 leafIndex)
         external
         view
-        returns (uint256 collateralGwei);
+        returns (uint256 collateralWei);
 
     function getSlasherCommitment(bytes32 registrationRoot, address slasher)
         external
@@ -230,5 +230,5 @@ interface IRegistry {
         bytes32[] calldata proof,
         uint256 leafIndex,
         address slasher
-    ) external view returns (SlasherCommitment memory slasherCommitment, uint256 collateralGwei);
+    ) external view returns (SlasherCommitment memory slasherCommitment, uint256 collateralWei);
 }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -37,6 +37,8 @@ interface IRegistry {
         uint48 slashedAt;
         /// A field to simulate deletion of the operator, since deleting a struct with a nested mapping is not safe
         bool deleted;
+        /// Whether the operator has equivocated or not
+        bool equivocated;
         /// Mapping to track opt-in and opt-out status for proposer commitment protocols
         mapping(address slasher => SlasherCommitment) slasherCommitments;
         /// Historical collateral records
@@ -154,6 +156,8 @@ interface IRegistry {
     error InvalidDelegation();
     error DifferentSlots();
     error DelegationsAreSame();
+    error OperatorAlreadyEquivocated();
+    error TimestampTooOld();
     error AlreadyOptedIn();
     error NotOptedIn();
     error OptInDelayNotMet();

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -94,8 +94,7 @@ interface IRegistry {
 
     /// @notice Emitted when an operator is unregistered
     /// @param registrationRoot The merkle root of the registration merkle tree
-    /// @param unregisteredAt The block number when the operator was unregistered
-    event OperatorUnregistered(bytes32 indexed registrationRoot, uint48 unregisteredAt);
+    event OperatorUnregistered(bytes32 indexed registrationRoot);
 
     /// @notice Emitted when collateral is claimed
     /// @param registrationRoot The merkle root of the registration merkle tree

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -35,6 +35,8 @@ interface IRegistry {
         uint48 unregisteredAt;
         /// The block number when slashed from breaking a commitment
         uint48 slashedAt;
+        /// A field to simulate deletion of the operator, since deleting a struct with a nested mapping is not safe
+        bool deleted;
         /// Mapping to track opt-in and opt-out status for proposer commitment protocols
         mapping(address slasher => SlasherCommitment) slasherCommitments;
         /// Historical collateral records
@@ -126,6 +128,7 @@ interface IRegistry {
      */
     error InsufficientCollateral();
     error OperatorAlreadyRegistered();
+    error OperatorDeleted();
     error InvalidRegistrationRoot();
     error EthTransferFailed();
     error WrongOperator();

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -266,4 +266,6 @@ interface IRegistry {
     function getConfig() external view returns (Config memory config);
 
     function getOperatorData(bytes32 registrationRoot) external view returns (OperatorData memory operatorData);
+
+    function slashingEvidenceAlreadyUsed(bytes32 slashingDigest) external view returns (bool);
 }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -47,12 +47,14 @@ interface IRegistry {
 
     /// @notice A struct to track opt-in and opt-out status for proposer commitment protocols
     struct SlasherCommitment {
-        /// The block number when the operator opted in
-        uint64 optedInAt;
-        /// The block number when the operator opted out
-        uint64 optedOutAt;
         /// The address of the key used for commitments
         address committer;
+        /// The block number when the operator opted in
+        uint48 optedInAt;
+        /// The block number when the operator opted out
+        uint48 optedOutAt;
+        /// Whether they have been slashed or not
+        bool slashed;
     }
 
     /// @notice A record of collateral at a specific timestamp

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -28,7 +28,7 @@ interface IRegistry {
     }
 
     /// @notice A registration of a BLS key
-    struct Registration {
+    struct SignedRegistration {
         /// BLS public key
         BLS.G1Point pubkey;
         /// BLS signature
@@ -194,7 +194,7 @@ interface IRegistry {
      *
      */
 
-    function register(Registration[] calldata registrations, address owner)
+    function register(SignedRegistration[] calldata registrations, address owner)
         external
         payable
         returns (bytes32 registrationRoot);
@@ -207,7 +207,7 @@ interface IRegistry {
 
     function slashRegistration(
         bytes32 registrationRoot,
-        Registration calldata reg,
+        SignedRegistration calldata reg,
         bytes32[] calldata proof,
         uint256 leafIndex
     ) external returns (uint256 collateralWei);
@@ -257,7 +257,7 @@ interface IRegistry {
 
     function getOptedInCommitter(
         bytes32 registrationRoot,
-        Registration calldata reg,
+        SignedRegistration calldata reg,
         bytes32[] calldata proof,
         uint256 leafIndex,
         address slasher

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -161,7 +161,8 @@ interface IRegistry {
     error AlreadyOptedIn();
     error NotOptedIn();
     error OptInDelayNotMet();
-
+    error InvalidProof();
+    error NoCollateral();
     /**
      *
      *                                *
@@ -169,6 +170,7 @@ interface IRegistry {
      *                                *
      *
      */
+
     function register(Registration[] calldata registrations, address owner)
         external
         payable

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -222,7 +222,6 @@ interface IRegistry {
         payable
         returns (bytes32 registrationRoot);
 
-
     /// @notice Starts the process to unregister an operator from the URC
     /// @dev The function will mark the `unregisteredAt` timestamp in the Operator struct. The operator can claim their collateral after the `unregistrationDelay` more blocks have passed.
     /// @dev The function will revert if:
@@ -310,7 +309,7 @@ interface IRegistry {
     /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
     /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
     /// @return slashAmountWei The amount of WEI slashed
-    function slashCommitmentFromOptIn(
+    function slashCommitment(
         bytes32 registrationRoot,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
@@ -392,24 +391,17 @@ interface IRegistry {
         external
         view
         returns (SlasherCommitment memory);
-    
+
     /// @notice Returns true if the operator has been slashed
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @return slashed True if the operator has been slashed, false otherwise
-    function isSlashed(bytes32 registrationRoot)
-        external
-        view
-        returns (bool slashed);
-    
- 
+    function isSlashed(bytes32 registrationRoot) external view returns (bool slashed);
+
     /// @notice Returns true if the operator has been slashed for a given slasher
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param slasher The address of the slasher to check
     /// @return slashed True if the operator has been slashed, false otherwise
-    function isSlashed(bytes32 registrationRoot, address slasher)
-        external
-        view
-        returns (bool slashed);
+    function isSlashed(bytes32 registrationRoot, address slasher) external view returns (bool slashed);
 
     /// @notice Checks if an operator is opted into a protocol and hasn't been slashed
     /// @param registrationRoot The merkle root generated and stored from the register() function

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -251,17 +251,21 @@ interface IRegistry {
     function getSlasherCommitment(bytes32 registrationRoot, address slasher)
         external
         view
-        returns (SlasherCommitment memory slasherCommitment);
+        returns (SlasherCommitment memory);
 
     function isOptedIntoSlasher(bytes32 registrationRoot, address slasher) external view returns (bool);
 
-    function getOptedInCommitter(
+    function getVerifiedOperatorData(
         bytes32 registrationRoot,
         SignedRegistration calldata reg,
         bytes32[] calldata proof,
-        uint256 leafIndex,
-        address slasher
-    ) external view returns (SlasherCommitment memory slasherCommitment, uint256 collateralWei);
+        uint256 leafIndex
+    ) external view returns (OperatorData memory);
+
+    function getHistoricalCollateral(bytes32 registrationRoot, uint256 timestamp)
+        external
+        view
+        returns (uint256 collateralWei);
 
     function getConfig() external view returns (Config memory config);
 

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -206,19 +206,89 @@ interface IRegistry {
      *                                *
      *
      */
+
+    /// @notice Batch registers an operator's BLS keys and collateral to the URC
+    /// @dev SignedRegistration signatures are optimistically verified. They are expected to be signed with the `DOMAIN_SEPARATOR` mixin.
+    /// @dev The function will merkleize the supplied `registrations` and map the registration merkle root to an Operator struct.
+    /// @dev The function will revert if:
+    /// @dev - They sent less than `config.minCollateralWei` (InsufficientCollateral)
+    /// @dev - The operator has already registered the same `registrations` (OperatorAlreadyRegistered)
+    /// @dev - The registration root is invalid (InvalidRegistrationRoot)
+    /// @param registrations The BLS keys to register
+    /// @param owner The authorized address to perform actions on behalf of the operator
+    /// @return registrationRoot The merkle root of the registration
     function register(SignedRegistration[] calldata registrations, address owner)
         external
         payable
         returns (bytes32 registrationRoot);
 
+
+    /// @notice Starts the process to unregister an operator from the URC
+    /// @dev The function will mark the `unregisteredAt` timestamp in the Operator struct. The operator can claim their collateral after the `unregistrationDelay` more blocks have passed.
+    /// @dev The function will revert if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The caller is not the operator's owner (WrongOperator)
+    /// @dev - The operator has already unregistered (AlreadyUnregistered)
+    /// @dev - The operator has been slashed (SlashingAlreadyOccurred)
+    /// @param registrationRoot The merkle root generated and stored from the register() function
     function unregister(bytes32 registrationRoot) external;
 
+    /// @notice Opts an operator into a proposer commtiment protocol via Slasher contract
+    /// @dev The function will revert if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The caller is not the operator's owner (WrongOperator)
+    /// @dev - The fraud proof window has not passed (FraudProofWindowNotMet)
+    /// @dev - The operator has already been slashed (SlashingAlreadyOccurred)
+    /// @dev - The operator has already opted in (AlreadyOptedIn)
+    /// @dev - The opt-in delay has not passed (OptInDelayNotMet)
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param slasher The address of the Slasher contract to opt into
+    /// @param committer The address of the key to be used for making commitments
     function optInToSlasher(bytes32 registrationRoot, address slasher, address committer) external;
 
+    /// @notice Opts an operator out of a slasher
+    /// @dev The function will revert if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The caller is not the operator's owner (WrongOperator)
+    /// @dev - The operator has is not currently opted in (NotOptedIn)
+    /// @dev - The opt-in delay has not passed (OptInDelayNotMet)
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param slasher The address of the Slasher contract to opt out of
     function optOutOfSlasher(bytes32 registrationRoot, address slasher) external;
 
-    function slashRegistration(RegistrationProof calldata proof) external returns (uint256 collateralWei);
+    /// @notice Slash an operator for previously submitting a fraudulent `SignedRegistration` in the register() function
+    /// @dev To save BLS verification gas costs, the URC optimistically accepts registration signatures. This function allows a challenger to slash the operator by executing the BLS verification logic to prove the registration was fraudulent.
+    /// @dev A successful challenge will transfer `config.minCollateralWei / 2` to the challenger, burn `config.minCollateralWei / 2`, and then allow the operator to claim their remaining collateral after `config.slashWindow` blocks have elapsed from the `claimSlashedCollateral()` function.
+    /// @dev The function will revert if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The fraud proof window has expired (FraudProofWindowExpired)
+    /// @dev - The operator has no collateral (NoCollateral)
+    /// @dev - The operator's collateral is less than the minimum collateral (CollateralBelowMinimum)
+    /// @dev - The registration merkle proof is invalid (InvalidProof)
+    /// @dev - The BLS signature was actually valid (FraudProofChallengeInvalid)
+    /// @dev - ETH transfer to challenger fails (EthTransferFailed)
+    /// @param proof The merkle proof to verify the operator's key is in the registry
+    /// @return slashedCollateralWei The amount of WEI slashed
+    function slashRegistration(RegistrationProof calldata proof) external returns (uint256 slashedCollateralWei);
 
+    /// @notice Slashes an operator for breaking a commitment
+    /// @dev The function verifies `proof` to first ensure the operator's BLS key is in the registry, then verifies the `signedDelegation` was signed by the same key. If the fraud proof window has passed, the URC will call the `slash()` function of the Slasher contract specified in the `signedCommitment`. The Slasher contract will determine if the operator has broken a commitment and return the amount of WEI to be slashed at the URC.
+    /// @dev The function will burn `slashAmountWei`. It will also save the timestamp of the slashing to start the `config.slashWindow` in case of multiple slashings.
+    /// @dev The function will revert if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The same slashing inputs have been supplied before (SlashingAlreadyOccurred)
+    /// @dev - The fraud proof window has not passed (FraudProofWindowNotMet)
+    /// @dev - The operator has already unregistered (OperatorAlreadyUnregistered)
+    /// @dev - The slash window has expired (SlashWindowExpired)
+    /// @dev - The merkle proof is invalid (InvalidProof)
+    /// @dev - The signed delegation was not signed by the operator's BLS key (DelegationSignatureInvalid)
+    /// @dev - The commitment was not signed by the delegated committer address (UnauthorizedCommitment)
+    /// @dev - The slash amount exceeds the operator's collateral (SlashAmountExceedsCollateral)
+    /// @param proof The merkle proof to verify the operator's key is in the registry
+    /// @param delegation The SignedDelegation signed by the operator's BLS key
+    /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
+    /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
+    /// @return slashAmountWei The amount of WEI slashed
     function slashCommitment(
         RegistrationProof calldata proof,
         ISlasher.SignedDelegation calldata delegation,
@@ -226,48 +296,154 @@ interface IRegistry {
         bytes calldata evidence
     ) external returns (uint256 slashAmountWei);
 
+    /// @notice Slashes an operator for breaking a commitment in a protocol they opted into via the optInToSlasher() function. The operator must have already opted into the protocol.
+    /// @dev The function verifies the commitment was signed by the registered committer from the optInToSlasher() function before calling into the Slasher contract.
+    /// @dev Reverts if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The fraud proof window has not passed (FraudProofWindowNotMet)
+    /// @dev - The operator has already unregistered and delay passed (OperatorAlreadyUnregistered)
+    /// @dev - The slash window has expired (SlashWindowExpired)
+    /// @dev - The operator has not opted into the slasher (NotOptedIn)
+    /// @dev - The commitment was not signed by registered committer (UnauthorizedCommitment)
+    /// @dev - The slash amount exceeds operator's collateral (SlashAmountExceedsCollateral)
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
+    /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
+    /// @return slashAmountWei The amount of WEI slashed
     function slashCommitmentFromOptIn(
         bytes32 registrationRoot,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
     ) external returns (uint256 slashAmountWei);
 
+    /// @notice Slash an operator for equivocation (signing two different delegations for the same slot)
+    /// @dev A successful challenge will transfer `config.minCollateralWei / 2` to the challenger, burn `config.minCollateralWei / 2`, and then allow the operator to claim their remaining collateral after `config.slashWindow` blocks have elapsed from the `claimSlashedCollateral()` function.
+    /// @dev Reverts if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The operator has already equivocated (OperatorAlreadyEquivocated)
+    /// @dev - The delegations are the same (DelegationsAreSame)
+    /// @dev - The fraud proof window has not passed (FraudProofWindowNotMet)
+    /// @dev - The operator has already unregistered and delay passed (OperatorAlreadyUnregistered)
+    /// @dev - The slash window has expired (SlashWindowExpired)
+    /// @dev - The merkle proof is invalid (InvalidProof)
+    /// @dev - Either delegation is invalid (InvalidDelegation)
+    /// @dev - The delegations are for different slots (DifferentSlots)
+    /// @dev - ETH transfer to challenger fails (EthTransferFailed)
+    /// @param proof The merkle proof to verify the operator's key is in the registry
+    /// @param delegationOne The first SignedDelegation signed by the operator's BLS key
+    /// @param delegationTwo The second SignedDelegation signed by the operator's BLS key
+    /// @return slashAmountWei The amount of WEI slashed
     function slashEquivocation(
         RegistrationProof calldata proof,
         ISlasher.SignedDelegation calldata delegationOne,
         ISlasher.SignedDelegation calldata delegationTwo
     ) external returns (uint256 slashAmountWei);
 
+    /// @notice Adds collateral to an Operator struct
+    /// @dev The function will revert if:
+    /// @dev - The operator was deleted (OperatorDeleted)
+    /// @dev - The operator is at 0 wei collateral (NoCollateral)
+    /// @dev - The input collateral amount overflows the `collateralWei` field (CollateralOverflow)
+    /// @param registrationRoot The merkle root generated and stored from the register() function
     function addCollateral(bytes32 registrationRoot) external payable;
 
+    /// @notice Retrieves an operator's collateral after the unregistration delay has elapsed
+    /// @dev The function will revert if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The operator has not previously unregistered via `unregister()` (NotUnregistered)
+    /// @dev - The `unregistrationDelay` has not passed (UnregistrationDelayNotMet)
+    /// @dev - The operator was slashed (they will need to call `claimSlashedCollateral()`) (SlashingAlreadyOccurred)
+    /// @dev - ETH transfer to operator fails (EthTransferFailed)
+    /// @dev The function will transfer the operator's collateral to their registered `owner` address.
+    /// @param registrationRoot The merkle root generated and stored from the register() function
     function claimCollateral(bytes32 registrationRoot) external;
 
+    /// @notice Retrieves an operator's collateral if they have been slashed before
+    /// @dev The function will revert if:
+    /// @dev - The operator has already been deleted (OperatorDeleted)
+    /// @dev - The operator has not been slashed (NotSlashed)
+    /// @dev - The slash window has not passed (SlashWindowNotMet)
+    /// @dev - ETH transfer to operator fails (EthTransferFailed)
     function claimSlashedCollateral(bytes32 registrationRoot) external;
 
     // =========== getter functions ===========
 
+    /// @notice Get the configuration of the registry
+    /// @return config The configuration of the registry
+    function getConfig() external view returns (Config memory config);
+
+    /// @notice Returns information about an operator
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @return operatorData The data about the operator
+    function getOperatorData(bytes32 registrationRoot) external view returns (OperatorData memory operatorData);
+
+    /// @notice Verify a merkle proof against a given `RegistrationProof`
+    /// @dev The function will revert if the proof is invalid
+    /// @dev The function checks against registered operators to get the owner address and
+    /// @dev should revert if the proof doesn't correspond to a real registration
+    /// @param proof The merkle proof to verify the operator's key is in the registry
     function verifyMerkleProof(RegistrationProof calldata proof) external view;
 
+    /// @notice Checks if an operator is opted into a protocol
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param slasher The address of the slasher to check
+    /// @return slasherCommitment The slasher commitment (default values if not opted in)
     function getSlasherCommitment(bytes32 registrationRoot, address slasher)
         external
         view
         returns (SlasherCommitment memory);
+    
+    /// @notice Returns true if the operator has been slashed
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @return slashed True if the operator has been slashed, false otherwise
+    function isSlashed(bytes32 registrationRoot)
+        external
+        view
+        returns (bool slashed);
+    
+ 
+    /// @notice Returns true if the operator has been slashed for a given slasher
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param slasher The address of the slasher to check
+    /// @return slashed True if the operator has been slashed, false otherwise
+    function isSlashed(bytes32 registrationRoot, address slasher)
+        external
+        view
+        returns (bool slashed);
 
+    /// @notice Checks if an operator is opted into a protocol and hasn't been slashed
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param slasher The address of the slasher to check
+    /// @return True if the operator is opted in and hasn't been slashed, false otherwise
     function isOptedIntoSlasher(bytes32 registrationRoot, address slasher) external view returns (bool);
 
+    /// @notice Returns the operator data for a given `RegistrationProof` iff the proof is valid
+    /// @dev The function will revert if the proof is invalid
+    /// @param proof The merkle proof to verify the operator's key is in the registry
+    /// @return operatorData The operator data
     function getVerifiedOperatorData(RegistrationProof calldata proof) external view returns (OperatorData memory);
 
+    /// @notice Checks if a slashing has already occurred with the same input
+    /// @dev The getter for the `slashedBefore` mapping
+    /// @param slashingDigest The digest of the slashing evidence
+    /// @return True if the slashing has already occurred, false otherwise
+    function slashingEvidenceAlreadyUsed(bytes32 slashingDigest) external view returns (bool);
+
+    /// @notice Retrieves the historical collateral value for an operator at a given timestamp
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param timestamp The timestamp to retrieve the collateral value for
+    /// @return collateralWei The collateral amount in WEI at the closest recorded timestamp
     function getHistoricalCollateral(bytes32 registrationRoot, uint256 timestamp)
         external
         view
         returns (uint256 collateralWei);
 
-    function getConfig() external view returns (Config memory config);
-
-    function getOperatorData(bytes32 registrationRoot) external view returns (OperatorData memory operatorData);
-
-    function slashingEvidenceAlreadyUsed(bytes32 slashingDigest) external view returns (bool);
-
+    /// @notice Returns a `RegistrationProof` for a given `SignedRegistration` array
+    /// @dev This function is not intended to be called on-chain due to gas costs
+    /// @param regs The array of all `SignedRegistration` structs submitted during the initial call to `register()`
+    /// @param owner The owner address of the operator
+    /// @param leafIndex The index of the leaf the proof is for
+    /// @return proof The `RegistrationProof` for the given `SignedRegistration` array
     function getRegistrationProof(SignedRegistration[] calldata regs, address owner, uint256 leafIndex)
         external
         pure

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -35,8 +35,9 @@ interface IRegistry {
         BLS.G2Point signature;
     }
 
-    /// @notice An operator of BLS key[s]
-    struct Operator {
+    /// @notice Data about an operator
+    /// @dev Since mappings cannot be returned from a contract, this struct is used to return operator data
+    struct OperatorData {
         /// The authorized address of the operator
         address owner;
         /// ETH collateral in WEI
@@ -53,6 +54,12 @@ interface IRegistry {
         bool deleted;
         /// Whether the operator has equivocated or not
         bool equivocated;
+    }
+
+    /// @notice An operator of BLS key[s]
+    struct Operator {
+        /// The data about the operator
+        OperatorData data;
         /// Mapping to track opt-in and opt-out status for proposer commitment protocols
         mapping(address slasher => SlasherCommitment) slasherCommitments;
         /// Historical collateral records
@@ -255,4 +262,8 @@ interface IRegistry {
         uint256 leafIndex,
         address slasher
     ) external view returns (SlasherCommitment memory slasherCommitment, uint256 collateralWei);
+
+    function getConfig() external view returns (Config memory config);
+
+    function getOperatorData(bytes32 registrationRoot) external view returns (OperatorData memory operatorData);
 }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -13,6 +13,20 @@ interface IRegistry {
      *
      */
 
+    /// @notice A struct to track the configuration of the registry
+    struct Config {
+        /// The minimum collateral required to register
+        uint80 minCollateralWei;
+        /// The fraud proof window
+        uint32 fraudProofWindow;
+        /// The unregistration delay
+        uint32 unregistrationDelay;
+        /// The slash window
+        uint32 slashWindow;
+        /// The opt-in delay
+        uint32 optInDelay;
+    }
+
     /// @notice A registration of a BLS key
     struct Registration {
         /// BLS public key

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -50,21 +50,21 @@ interface ISlasher {
     /// @param commitment The commitment message
     /// @param evidence Arbitrary evidence for the slashing
     /// @param challenger The address of the challenger
-    /// @return slashAmountGwei The amount of Gwei slashed
+    /// @return slashAmountWei The amount of WEI slashed
     function slash(
         Delegation calldata delegation,
         Commitment calldata commitment,
         bytes calldata evidence,
         address challenger
-    ) external returns (uint256 slashAmountGwei);
+    ) external returns (uint256 slashAmountWei);
 
     /// @notice Slash an operator for a given commitment
     /// @dev The URC will call this function to slash a registered operator if supplied with a valid commitment and evidence. The assumption is that the operator has opted into the slasher protocol on-chain.
     /// @param commitment The commitment message
     /// @param evidence Arbitrary evidence for the slashing
     /// @param challenger The address of the challenger
-    /// @return slashAmountGwei The amount of Gwei slashed
+    /// @return slashAmountWei The amount of WEI slashed
     function slashFromOptIn(Commitment calldata commitment, bytes calldata evidence, address challenger)
         external
-        returns (uint256 slashAmountGwei);
+        returns (uint256 slashAmountWei);
 }

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -111,7 +111,7 @@ contract Registry is IRegistry {
         // Save the block number; they must wait for the unregistration delay to claim collateral
         operator.unregisteredAt = uint48(block.number);
 
-        emit OperatorUnregistered(registrationRoot, operator.unregisteredAt);
+        emit OperatorUnregistered(registrationRoot);
     }
 
     /// @notice Opts an operator into a proposer commtiment protocol via Slasher contract

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -249,13 +249,19 @@ contract Registry is IRegistry {
         uint256 remainingWei = uint256(collateralGwei) * 1 gwei - MIN_COLLATERAL;
 
         // Transfer to the challenger
-        (bool success,) = msg.sender.call{ value: MIN_COLLATERAL }("");
+        bool success;
+        address challenger = msg.sender;
+        assembly ("memory-safe") {
+            success := call(gas(), challenger, MIN_COLLATERAL, 0, 0, 0, 0)
+        }
         if (!success) {
             revert EthTransferFailed();
         }
 
         // Return any remaining funds to owner
-        (success,) = owner.call{ value: remainingWei }("");
+        assembly ("memory-safe") {
+            success := call(gas(), owner, remainingWei, 0, 0, 0, 0)
+        }
         if (!success) {
             revert EthTransferFailed();
         }
@@ -532,7 +538,11 @@ contract Registry is IRegistry {
         slashedBefore[keccak256(abi.encode(delegationTwo, delegationOne, registrationRoot))] = true;
 
         // Reward the challenger
-        (bool success,) = msg.sender.call{ value: MIN_COLLATERAL }("");
+        bool success;
+        address challenger = msg.sender;
+        assembly ("memory-safe") {
+            success := call(gas(), challenger, MIN_COLLATERAL, 0, 0, 0, 0)
+        }
         if (!success) {
             revert EthTransferFailed();
         }
@@ -604,7 +614,11 @@ contract Registry is IRegistry {
         delete registrations[registrationRoot];
 
         // Transfer to operator
-        (bool success,) = operatorOwner.call{ value: collateralGwei * 1 gwei }("");
+        bool success;
+        uint256 collateral = collateralGwei * 1 gwei;
+        assembly ("memory-safe") {
+            success := call(gas(), operatorOwner, collateral, 0, 0, 0, 0)
+        }
         if (!success) {
             revert EthTransferFailed();
         }
@@ -631,7 +645,11 @@ contract Registry is IRegistry {
         delete registrations[registrationRoot];
 
         // Transfer collateral to owner
-        (bool success,) = owner.call{ value: collateralGwei * 1 gwei }("");
+        bool success;
+        uint256 collateral = collateralGwei * 1 gwei;
+        assembly ("memory-safe") {
+            success := call(gas(), owner, collateral, 0, 0, 0, 0)
+        }
         if (!success) {
             revert EthTransferFailed();
         }
@@ -813,7 +831,12 @@ contract Registry is IRegistry {
     /// @param amountGwei The amount of GWEI to be burned
     function _burnGwei(uint256 amountGwei) internal {
         // Burn the slash amount
-        (bool success,) = BURNER_ADDRESS.call{ value: amountGwei * 1 gwei }("");
+        bool success;
+        address burner = BURNER_ADDRESS;
+        uint256 collateral = amountGwei * 1 gwei;
+        assembly ("memory-safe") {
+            success := call(gas(), burner, collateral, 0, 0, 0, 0)
+        }
         if (!success) {
             revert EthTransferFailed();
         }

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -68,18 +68,18 @@ contract Registry is IRegistry {
         // Each Operator is mapped to a unique registration root
         Operator storage newOperator = registrations[registrationRoot];
         newOperator.owner = owner;
-        newOperator.collateralGwei = uint56(msg.value / 1 gwei);
-        newOperator.numKeys = uint8(regs.length);
-        newOperator.registeredAt = uint32(block.number);
-        newOperator.unregisteredAt = type(uint32).max;
+        newOperator.collateralWei = uint80(msg.value);
+        newOperator.numKeys = uint16(regs.length);
+        newOperator.registeredAt = uint48(block.number);
+        newOperator.unregisteredAt = type(uint48).max;
         newOperator.slashedAt = 0;
 
         // Store the initial collateral value in the history
         newOperator.collateralHistory.push(
-            CollateralRecord({ timestamp: uint64(block.timestamp), collateralValue: uint56(msg.value / 1 gwei) })
+            CollateralRecord({ timestamp: uint64(block.timestamp), collateralValue: uint80(msg.value) })
         );
 
-        emit OperatorRegistered(registrationRoot, uint56(msg.value / 1 gwei), owner);
+        emit OperatorRegistered(registrationRoot, msg.value, owner);
     }
 
     /// @notice Starts the process to unregister an operator from the URC
@@ -98,7 +98,7 @@ contract Registry is IRegistry {
         }
 
         // Prevent double unregistrations
-        if (operator.unregisteredAt != type(uint32).max) {
+        if (operator.unregisteredAt != type(uint48).max) {
             revert AlreadyUnregistered();
         }
 
@@ -109,7 +109,7 @@ contract Registry is IRegistry {
         }
 
         // Save the block number; they must wait for the unregistration delay to claim collateral
-        operator.unregisteredAt = uint32(block.number);
+        operator.unregisteredAt = uint48(block.number);
 
         emit OperatorUnregistered(registrationRoot, operator.unregisteredAt);
     }
@@ -227,10 +227,10 @@ contract Registry is IRegistry {
         }
 
         // Verify the registration is part of the registry
-        uint256 collateralGwei = _verifyMerkleProof(registrationRoot, keccak256(abi.encode(reg)), proof, leafIndex);
+        uint256 collateralWei = _verifyMerkleProof(registrationRoot, keccak256(abi.encode(reg)), proof, leafIndex);
 
         // 0 collateral implies the registration was not part of the registry
-        if (collateralGwei == 0) {
+        if (collateralWei == 0) {
             revert NotRegisteredKey();
         }
 
@@ -246,7 +246,7 @@ contract Registry is IRegistry {
         delete registrations[registrationRoot];
 
         // Calculate the amount to transfer to challenger and return to owner
-        uint256 remainingWei = uint256(collateralGwei) * 1 gwei - MIN_COLLATERAL;
+        uint256 remainingWei = collateralWei - MIN_COLLATERAL;
 
         // Transfer to the challenger
         bool success;
@@ -290,7 +290,7 @@ contract Registry is IRegistry {
     /// @param delegation The SignedDelegation signed by the operator's BLS key
     /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
     /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
-    /// @return slashAmountGwei The amount of GWEI slashed
+    /// @return slashAmountWei The amount of WEI slashed
     function slashCommitment(
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
@@ -299,7 +299,7 @@ contract Registry is IRegistry {
         ISlasher.SignedDelegation calldata delegation,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountWei) {
         Operator storage operator = registrations[registrationRoot];
 
         bytes32 slashingDigest = keccak256(abi.encode(delegation, commitment, registrationRoot));
@@ -316,7 +316,7 @@ contract Registry is IRegistry {
 
         // Operator is not liable for slashings after unregister and the delay has passed
         if (
-            operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
+            operator.unregisteredAt != type(uint48).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
         ) {
             revert OperatorAlreadyUnregistered();
         }
@@ -329,8 +329,7 @@ contract Registry is IRegistry {
 
         // Verify the delegation was signed by the operator's BLS key
         // This is a sanity check to ensure the delegation is valid
-        uint256 collateralGwei =
-            _verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegation);
+        uint256 collateralWei = _verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegation);
 
         // Verify the commitment was signed by the commitment key from the Delegation
         address committer = ECDSA.recover(keccak256(abi.encode(commitment.commitment)), commitment.signature);
@@ -339,25 +338,25 @@ contract Registry is IRegistry {
         }
 
         // Call the Slasher contract to slash the operator
-        slashAmountGwei = ISlasher(commitment.commitment.slasher).slash(
+        slashAmountWei = ISlasher(commitment.commitment.slasher).slash(
             delegation.delegation, commitment.commitment, evidence, msg.sender
         );
 
         // Prevent slashing more than the operator's collateral
-        if (slashAmountGwei > collateralGwei) {
+        if (slashAmountWei > collateralWei) {
             revert SlashAmountExceedsCollateral();
         }
 
         // Burn the slashed amount
-        _burnGwei(slashAmountGwei);
+        _burnETH(slashAmountWei);
 
         // Save timestamp only once to start the slash window
         if (operator.slashedAt == 0) {
-            operator.slashedAt = uint32(block.number);
+            operator.slashedAt = uint48(block.number);
         }
 
         // Decrement operator's collateral
-        operator.collateralGwei -= uint56(slashAmountGwei);
+        operator.collateralWei -= uint80(slashAmountWei);
 
         // Prevent same slashing from occurring again
         slashedBefore[slashingDigest] = true;
@@ -368,7 +367,7 @@ contract Registry is IRegistry {
             operator.owner,
             msg.sender,
             commitment.commitment.slasher,
-            slashAmountGwei
+            slashAmountWei
         );
     }
 
@@ -384,11 +383,12 @@ contract Registry is IRegistry {
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param commitment The SignedCommitment signed by the delegate's ECDSA key
     /// @param evidence Arbitrary evidence to slash the operator, required by the Slasher contract
+    /// @return slashAmountWei The amount of WEI slashed
     function slashCommitmentFromOptIn(
         bytes32 registrationRoot,
         ISlasher.SignedCommitment calldata commitment,
         bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountWei) {
         Operator storage operator = registrations[registrationRoot];
         address slasher = commitment.commitment.slasher;
 
@@ -399,7 +399,7 @@ contract Registry is IRegistry {
 
         // Operator is not liable for slashings after unregister and the delay has passed
         if (
-            operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
+            operator.unregisteredAt != type(uint48).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
         ) {
             revert OperatorAlreadyUnregistered();
         }
@@ -425,40 +425,34 @@ contract Registry is IRegistry {
         }
 
         // Call the Slasher contract to slash the operator
-        slashAmountGwei = ISlasher(slasher).slashFromOptIn(commitment.commitment, evidence, msg.sender);
+        slashAmountWei = ISlasher(slasher).slashFromOptIn(commitment.commitment, evidence, msg.sender);
 
         // Prevent slashing more than the operator's collateral
-        if (slashAmountGwei > operator.collateralGwei) {
+        if (slashAmountWei > operator.collateralWei) {
             revert SlashAmountExceedsCollateral();
         }
 
         // Save timestamp only once to start the slash window
         if (operator.slashedAt == 0) {
-            operator.slashedAt = uint32(block.number);
+            operator.slashedAt = uint48(block.number);
         }
 
         // Decrement operator's collateral
-        operator.collateralGwei -= uint56(slashAmountGwei);
+        operator.collateralWei -= uint80(slashAmountWei);
 
         // Prevent same slashing from occurring again
         delete operator.slasherCommitments[slasher];
 
         emit OperatorSlashed(
-            SlashingType.Commitment, registrationRoot, operator.owner, msg.sender, slasher, slashAmountGwei
+            SlashingType.Commitment, registrationRoot, operator.owner, msg.sender, slasher, slashAmountWei
         );
 
         // Burn the slashed amount
-        _burnGwei(slashAmountGwei);
+        _burnETH(slashAmountWei);
     }
 
     /// @notice Slash an operator for equivocation (signing two different delegations for the same slot)
     /// @dev The function will slash the operator's collateral and transfer `MIN_COLLATERAL` to the msg.sender.
-    /// @param registrationRoot The merkle root generated and stored from the register() function
-    /// @param registrationSignature The signature from the operator's previously registered `Registration`
-    /// @param proof The merkle proof to verify the operator's key is in the registry
-    /// @param leafIndex The index of the leaf in the merkle tree
-    /// @param delegationOne The first SignedDelegation signed by the operator's BLS key
-    /// @param delegationTwo The second SignedDelegation signed by the operator's BLS key
     /// @dev Reverts if:
     /// @dev - The delegations are the same (DelegationsAreSame)
     /// @dev - The slashing has already occurred (SlashingAlreadyOccurred)
@@ -467,6 +461,13 @@ contract Registry is IRegistry {
     /// @dev - The slash window has expired (SlashWindowExpired)
     /// @dev - Either delegation is invalid (InvalidDelegation)
     /// @dev - The delegations are for different slots (DifferentSlots)
+    /// @param registrationRoot The merkle root generated and stored from the register() function
+    /// @param registrationSignature The signature from the operator's previously registered `Registration`
+    /// @param proof The merkle proof to verify the operator's key is in the registry
+    /// @param leafIndex The index of the leaf in the merkle tree
+    /// @param delegationOne The first SignedDelegation signed by the operator's BLS key
+    /// @param delegationTwo The second SignedDelegation signed by the operator's BLS key
+    /// @return slashAmountWei The amount of WEI slashed
     function slashEquivocation(
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
@@ -474,7 +475,7 @@ contract Registry is IRegistry {
         uint256 leafIndex,
         ISlasher.SignedDelegation calldata delegationOne,
         ISlasher.SignedDelegation calldata delegationTwo
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountWei) {
         Operator storage operator = registrations[registrationRoot];
 
         bytes32 slashingDigest = keccak256(abi.encode(delegationOne, delegationTwo, registrationRoot));
@@ -496,7 +497,7 @@ contract Registry is IRegistry {
 
         // Operator is not liable for slashings after unregister and the delay has passed
         if (
-            operator.unregisteredAt != type(uint32).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
+            operator.unregisteredAt != type(uint48).max && block.number > operator.unregisteredAt + UNREGISTRATION_DELAY
         ) {
             revert OperatorAlreadyUnregistered();
         }
@@ -523,13 +524,13 @@ contract Registry is IRegistry {
 
         // Save timestamp only once to start the slash window
         if (operator.slashedAt == 0) {
-            operator.slashedAt = uint32(block.number);
+            operator.slashedAt = uint48(block.number);
         }
 
-        slashAmountGwei = MIN_COLLATERAL / 1 gwei;
+        slashAmountWei = MIN_COLLATERAL;
 
         // Decrement operator's collateral
-        operator.collateralGwei -= uint56(slashAmountGwei);
+        operator.collateralWei -= uint80(slashAmountWei);
 
         // Prevent same slashing from occurring again
         slashedBefore[slashingDigest] = true;
@@ -548,7 +549,7 @@ contract Registry is IRegistry {
         }
 
         emit OperatorSlashed(
-            SlashingType.Equivocation, registrationRoot, operator.owner, msg.sender, address(this), slashAmountGwei
+            SlashingType.Equivocation, registrationRoot, operator.owner, msg.sender, address(this), slashAmountWei
         );
     }
 
@@ -563,22 +564,22 @@ contract Registry is IRegistry {
     /// @param registrationRoot The merkle root generated and stored from the register() function
     function addCollateral(bytes32 registrationRoot) external payable {
         Operator storage operator = registrations[registrationRoot];
-        if (operator.collateralGwei == 0) {
+        if (operator.collateralWei == 0) {
             revert NotRegisteredKey();
         }
 
-        if (msg.value / 1 gwei > type(uint56).max) {
+        if (msg.value > type(uint80).max) {
             revert CollateralOverflow();
         }
 
-        operator.collateralGwei += uint56(msg.value / 1 gwei);
+        operator.collateralWei += uint80(msg.value);
 
         // Store the updated collateral value in the history
         operator.collateralHistory.push(
-            CollateralRecord({ timestamp: uint64(block.timestamp), collateralValue: operator.collateralGwei })
+            CollateralRecord({ timestamp: uint64(block.timestamp), collateralValue: operator.collateralWei })
         );
 
-        emit CollateralAdded(registrationRoot, operator.collateralGwei);
+        emit CollateralAdded(registrationRoot, operator.collateralWei);
     }
 
     /// @notice Claims an operator's collateral after the unregistration delay
@@ -588,10 +589,10 @@ contract Registry is IRegistry {
     function claimCollateral(bytes32 registrationRoot) external {
         Operator storage operator = registrations[registrationRoot];
         address operatorOwner = operator.owner;
-        uint256 collateralGwei = operator.collateralGwei;
+        uint256 collateralWei = operator.collateralWei;
 
         // Check that they've unregistered
-        if (operator.unregisteredAt == type(uint32).max) {
+        if (operator.unregisteredAt == type(uint48).max) {
             revert NotUnregistered();
         }
 
@@ -606,7 +607,7 @@ contract Registry is IRegistry {
         }
 
         // Check there's collateral to claim
-        if (collateralGwei == 0) {
+        if (collateralWei == 0) {
             revert NoCollateralToClaim();
         }
 
@@ -615,21 +616,20 @@ contract Registry is IRegistry {
 
         // Transfer to operator
         bool success;
-        uint256 collateral = collateralGwei * 1 gwei;
         assembly ("memory-safe") {
-            success := call(gas(), operatorOwner, collateral, 0, 0, 0, 0)
+            success := call(gas(), operatorOwner, collateralWei, 0, 0, 0, 0)
         }
         if (!success) {
             revert EthTransferFailed();
         }
 
-        emit CollateralClaimed(registrationRoot, collateralGwei);
+        emit CollateralClaimed(registrationRoot, collateralWei);
     }
 
     function claimSlashedCollateral(bytes32 registrationRoot) external {
         Operator storage operator = registrations[registrationRoot];
         address owner = operator.owner;
-        uint256 collateralGwei = operator.collateralGwei;
+        uint256 collateralWei = operator.collateralWei;
 
         // Check that they've been slashed
         if (operator.slashedAt == 0) {
@@ -646,25 +646,24 @@ contract Registry is IRegistry {
 
         // Transfer collateral to owner
         bool success;
-        uint256 collateral = collateralGwei * 1 gwei;
         assembly ("memory-safe") {
-            success := call(gas(), owner, collateral, 0, 0, 0, 0)
+            success := call(gas(), owner, collateralWei, 0, 0, 0, 0)
         }
         if (!success) {
             revert EthTransferFailed();
         }
 
-        emit CollateralClaimed(registrationRoot, collateralGwei);
+        emit CollateralClaimed(registrationRoot, collateralWei);
     }
 
     /// @notice Retrieves the historical collateral value for an operator at a given timestamp
     /// @param registrationRoot The merkle root generated and stored from the register() function
     /// @param timestamp The timestamp to retrieve the collateral value for
-    /// @return collateralGwei The collateral amount in GWEI at the closest recorded timestamp
+    /// @return collateralWei The collateral amount in WEI at the closest recorded timestamp
     function getHistoricalCollateral(bytes32 registrationRoot, uint256 timestamp)
         external
         view
-        returns (uint256 collateralGwei)
+        returns (uint256 collateralWei)
     {
         CollateralRecord[] storage records = registrations[registrationRoot].collateralHistory;
         if (records.length == 0) {
@@ -701,13 +700,13 @@ contract Registry is IRegistry {
     /// @param leaf The leaf to verify
     /// @param proof The merkle proof to verify the operator's key is in the registry
     /// @param leafIndex The index of the leaf in the merkle tree
-    /// @return collateralGwei The collateral amount in GWEI
+    /// @return collateralWei The collateral amount in WEI
     function verifyMerkleProof(bytes32 registrationRoot, bytes32 leaf, bytes32[] calldata proof, uint256 leafIndex)
         external
         view
-        returns (uint256 collateralGwei)
+        returns (uint256 collateralWei)
     {
-        collateralGwei = _verifyMerkleProof(registrationRoot, leaf, proof, leafIndex);
+        collateralWei = _verifyMerkleProof(registrationRoot, leaf, proof, leafIndex);
     }
 
     /// @notice Checks if an operator is opted into a protocol
@@ -739,18 +738,18 @@ contract Registry is IRegistry {
     /// @param leafIndex The index of the leaf in the merkle tree
     /// @param slasher The address of the slasher to check
     /// @return slasherCommitment The slasher commitment (default values if not opted in)
-    /// @return collateralGwei The collateral amount in GWEI (0 if not opted in)
+    /// @return collateralWei The collateral amount in WEI (0 if not opted in)
     function getOptedInCommitter(
         bytes32 registrationRoot,
         Registration calldata reg,
         bytes32[] calldata proof,
         uint256 leafIndex,
         address slasher
-    ) external view returns (SlasherCommitment memory slasherCommitment, uint256 collateralGwei) {
+    ) external view returns (SlasherCommitment memory slasherCommitment, uint256 collateralWei) {
         Operator storage operator = registrations[registrationRoot];
         slasherCommitment = operator.slasherCommitments[slasher];
 
-        collateralGwei = _verifyMerkleProof(registrationRoot, keccak256(abi.encode(reg)), proof, leafIndex);
+        collateralWei = _verifyMerkleProof(registrationRoot, keccak256(abi.encode(reg)), proof, leafIndex);
     }
 
     /**
@@ -781,14 +780,14 @@ contract Registry is IRegistry {
     /// @param leaf The leaf to verify
     /// @param proof The merkle proof to verify the operator's key is in the registry
     /// @param leafIndex The index of the leaf in the merkle tree
-    /// @return collateralGwei The collateral amount in GWEI
+    /// @return collateralWei The collateral amount in WEI
     function _verifyMerkleProof(bytes32 registrationRoot, bytes32 leaf, bytes32[] calldata proof, uint256 leafIndex)
         internal
         view
-        returns (uint256 collateralGwei)
+        returns (uint256 collateralWei)
     {
         if (MerkleTree.verifyProofCalldata(registrationRoot, leaf, leafIndex, proof)) {
-            collateralGwei = registrations[registrationRoot].collateralGwei;
+            collateralWei = registrations[registrationRoot].collateralWei;
         }
     }
 
@@ -801,20 +800,20 @@ contract Registry is IRegistry {
     /// @param proof The merkle proof to verify the operator's key is in the registry
     /// @param leafIndex The index of the leaf in the merkle tree
     /// @param delegation The SignedDelegation signed by the operator's BLS key
-    /// @return collateralGwei The collateral amount in GWEI
+    /// @return collateralWei The collateral amount in WEI
     function _verifyDelegation(
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
         bytes32[] calldata proof,
         uint256 leafIndex,
         ISlasher.SignedDelegation calldata delegation
-    ) internal view returns (uint256 collateralGwei) {
+    ) internal view returns (uint256 collateralWei) {
         // Reconstruct leaf using pubkey in SignedDelegation to check equivalence
         bytes32 leaf = keccak256(abi.encode(delegation.delegation.proposer, registrationSignature));
 
-        collateralGwei = _verifyMerkleProof(registrationRoot, leaf, proof, leafIndex);
+        collateralWei = _verifyMerkleProof(registrationRoot, leaf, proof, leafIndex);
 
-        if (collateralGwei == 0) {
+        if (collateralWei == 0) {
             revert NotRegisteredKey();
         }
 
@@ -828,14 +827,13 @@ contract Registry is IRegistry {
 
     /// @notice Burns ether
     /// @dev The function will revert if the transfer to the BURNER_ADDRESS fails.
-    /// @param amountGwei The amount of GWEI to be burned
-    function _burnGwei(uint256 amountGwei) internal {
+    /// @param amountWei The amount of WEI to be burned
+    function _burnETH(uint256 amountWei) internal {
         // Burn the slash amount
         bool success;
         address burner = BURNER_ADDRESS;
-        uint256 collateral = amountGwei * 1 gwei;
         assembly ("memory-safe") {
-            success := call(gas(), burner, collateral, 0, 0, 0, 0)
+            success := call(gas(), burner, amountWei, 0, 0, 0, 0)
         }
         if (!success) {
             revert EthTransferFailed();

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -752,7 +752,6 @@ contract Registry is IRegistry {
         // Create leaf nodes by hashing Registration structs
         for (uint256 i = 0; i < regs.length; i++) {
             leaves[i] = keccak256(abi.encode(regs[i]));
-            emit KeyRegistered(i, regs[i], leaves[i]);
         }
 
         registrationRoot = MerkleTree.generateTree(leaves);

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -259,7 +259,7 @@ contract Registry is IRegistry {
 
         // 0 collateral implies the registration was not part of the registry
         if (verifiedCollateralGwei == 0) {
-            revert NotRegisteredKey();
+            revert NoCollateral();
         }
 
         // Reconstruct registration message
@@ -859,6 +859,8 @@ contract Registry is IRegistry {
     {
         if (MerkleTree.verifyProofCalldata(registrationRoot, leaf, leafIndex, proof)) {
             collateralWei = registrations[registrationRoot].collateralWei;
+        } else {
+            revert InvalidProof();
         }
     }
 
@@ -888,7 +890,7 @@ contract Registry is IRegistry {
         collateralWei = _verifyMerkleProof(registrationRoot, leaf, proof, leafIndex);
 
         if (collateralWei == 0) {
-            revert NotRegisteredKey();
+            revert InvalidProof();
         }
 
         // Reconstruct Delegation message

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -12,10 +12,10 @@ contract Registry is IRegistry {
     using BLS for *;
 
     /// @notice Mapping from registration merkle roots to Operator structs
-    mapping(bytes32 registrationRoot => Operator) public operators;
+    mapping(bytes32 registrationRoot => Operator) private operators;
 
     /// @notice Mapping to track if a slashing has occurred before with same input
-    mapping(bytes32 slashingDigest => bool) public slashedBefore;
+    mapping(bytes32 slashingDigest => bool) private slashedBefore;
 
     // Constants
     address internal constant BURNER_ADDRESS = address(0x0000000000000000000000000000000000000000);
@@ -842,6 +842,14 @@ contract Registry is IRegistry {
         slasherCommitment = operator.slasherCommitments[slasher];
 
         collateralWei = _verifyMerkleProof(registrationRoot, keccak256(abi.encode(reg)), proof, leafIndex);
+    }
+
+    /// @notice Checks if a slashing has already occurred with the same input
+    /// @dev The getter for the `slashedBefore` mapping
+    /// @param slashingDigest The digest of the slashing evidence
+    /// @return True if the slashing has already occurred, false otherwise
+    function slashingEvidenceAlreadyUsed(bytes32 slashingDigest) external view returns (bool) {
+        return slashedBefore[slashingDigest];
     }
 
     /**

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -595,8 +595,9 @@ contract Registry is IRegistry {
             revert OperatorDeleted();
         }
 
+        // Zero collateral implies they were previously slashed to 0 or did not exist and must re-register
         if (operator.collateralWei == 0) {
-            revert NotRegisteredKey();
+            revert NoCollateral();
         }
 
         if (msg.value > type(uint80).max) {
@@ -646,11 +647,6 @@ contract Registry is IRegistry {
         // Check that the operator has not been slashed
         if (operator.slashedAt != 0) {
             revert SlashingAlreadyOccurred();
-        }
-
-        // Check there's collateral to claim
-        if (collateralWei == 0) {
-            revert NoCollateralToClaim();
         }
 
         // Prevent the Operator from being reused

--- a/src/lib/MerkleTree.sol
+++ b/src/lib/MerkleTree.sol
@@ -30,10 +30,10 @@ library MerkleTree {
         for (uint256 i = 0; i < leaves.length; i++) {
             nodes[i] = leaves[i];
         }
-        // Fill remaining nodes with zero
-        for (uint256 i = leaves.length; i < _nextPowerOfTwo; i++) {
-            nodes[i] = bytes32(0);
-        }
+        // // Fill remaining nodes with zero
+        // for (uint256 i = leaves.length; i < _nextPowerOfTwo; i++) {
+        //     nodes[i] = bytes32(0);
+        // }
 
         // Build up the tree
         uint256 n = _nextPowerOfTwo;

--- a/src/lib/MerkleTree.sol
+++ b/src/lib/MerkleTree.sol
@@ -30,10 +30,6 @@ library MerkleTree {
         for (uint256 i = 0; i < leaves.length; i++) {
             nodes[i] = leaves[i];
         }
-        // // Fill remaining nodes with zero
-        // for (uint256 i = leaves.length; i < _nextPowerOfTwo; i++) {
-        //     nodes[i] = bytes32(0);
-        // }
 
         // Build up the tree
         uint256 n = _nextPowerOfTwo;

--- a/src/lib/MerkleTree.sol
+++ b/src/lib/MerkleTree.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 /**
  * @title MerkleTree
  * @dev Implementation of a binary Merkle tree with proof generation and verification
@@ -164,19 +166,12 @@ library MerkleTree {
     }
 
     /**
-     * @dev Returns the next power of 2 for a number <= 256
-     * @param x The number to find the next power of 2 for (must be <= 256)
+     * @dev Returns the next power of 2 larger than the input
+     * @param x The number to find the next power of 2 for
      * @return The next power of 2
      */
     function nextPowerOfTwo(uint256 x) internal pure returns (uint256) {
         if (x <= 1) return 1;
-        if (x <= 2) return 2;
-        if (x <= 4) return 4;
-        if (x <= 8) return 8;
-        if (x <= 16) return 16;
-        if (x <= 32) return 32;
-        if (x <= 64) return 64;
-        if (x <= 128) return 128;
-        return 256;
+        return 1 << Math.log2(x, Math.Rounding.Ceil);
     }
 }

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -230,7 +230,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         vm.warp(block.timestamp + slasher.CHALLENGE_WINDOW() + 1);
 
         // Merkle proof for URC registration
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         bytes32[] memory registrationProof = MerkleTree.generateProof(
             leaves,
             0 // leaf index
@@ -281,7 +281,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         vm.warp(block.timestamp + slasher.CHALLENGE_WINDOW() + 1);
 
         // Merkle proof for URC registration
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory registrationProof = MerkleTree.generateProof(leaves, leafIndex);
 

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -31,7 +31,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
 
     InclusionPreconfSlasher slasher;
     BLS.G1Point delegatePubKey;
-    uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
+    uint256 slashAmountWei = 1 ether;
     uint256 collateral = 1.1 ether;
     uint256 committerSecretKey;
     address committer;
@@ -39,7 +39,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
         registry = new Registry();
-        slasher = new InclusionPreconfSlasher(slashAmountGwei, address(registry));
+        slasher = new InclusionPreconfSlasher(slashAmountWei, address(registry));
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
         (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
         vm.deal(challenger, 100 ether);
@@ -248,9 +248,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
             abi.encode(inclusionProof)
         );
 
-        _verifySlashCommitmentBalances(
-            challenger, slashAmountGwei * 1 gwei, 0, challengerBalanceBefore, urcBalanceBefore
-        );
+        _verifySlashCommitmentBalances(challenger, slashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 
         // Retrieve operator data
         OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
@@ -259,7 +257,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");
 
         // Verify operator's collateralGwei is decremented
-        assertEq(operatorData.collateralGwei, collateral / 1 gwei - slashAmountGwei, "collateralGwei not decremented");
+        assertEq(operatorData.collateralWei, collateral - slashAmountWei, "collateralWei not decremented");
 
         // Verify the slashedBefore mapping is set
         bytes32 slashingDigest =

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -262,7 +262,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         // Verify the slashedBefore mapping is set
         bytes32 slashingDigest =
             keccak256(abi.encode(result.signedDelegation, signedCommitment, result.registrationRoot));
-        assertEq(registry.slashedBefore(slashingDigest), true, "slashedBefore not set");
+        assertEq(registry.slashingEvidenceAlreadyUsed(slashingDigest), true, "slashedBefore not set");
     }
 
     function test_revert_slash_wrongChallenger() public {

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -38,7 +38,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
 
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
-        registry = new Registry();
+        registry = new Registry(defaultConfig());
         slasher = new InclusionPreconfSlasher(slashAmountWei, address(registry));
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
         (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
@@ -83,8 +83,8 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         uint256 inclusionBlockNumber = 20_785_012;
 
         // Advance before the fraud proof window
-        vm.roll(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW());
-        vm.warp(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW() * 12);
+        vm.roll(inclusionBlockNumber - registry.getConfig().fraudProofWindow);
+        vm.warp(inclusionBlockNumber - registry.getConfig().fraudProofWindow * 12);
 
         // Register and delegate
         result = setupRegistration(operator, delegate, 9994114 - 100);
@@ -172,8 +172,8 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         vm.deal(alice, 100 ether);
 
         // Set block to before fraud proof window
-        vm.roll(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW());
-        vm.warp(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW() * 12);
+        vm.roll(inclusionBlockNumber - registry.getConfig().fraudProofWindow);
+        vm.warp(inclusionBlockNumber - registry.getConfig().fraudProofWindow * 12);
 
         // Register with a soon-to-expire delegation
         bytes memory metadata = abi.encode(delegate);

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -251,7 +251,7 @@ contract InclusionPreconfSlasherTest is UnitTestHelper, PreconfStructs {
         _verifySlashCommitmentBalances(challenger, slashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 
         // Retrieve operator data
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -170,7 +170,7 @@ contract UnregisterTester is UnitTestHelper {
 
         vm.startPrank(operator);
         vm.expectEmit(address(registry));
-        emit IRegistry.OperatorUnregistered(registrationRoot, uint48(block.number));
+        emit IRegistry.OperatorUnregistered(registrationRoot);
         registry.unregister(registrationRoot);
 
         OperatorData memory operatorData = getRegistrationData(registrationRoot);

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -462,9 +462,9 @@ contract AddCollateralTester is UnitTestHelper {
         assertEq(operatorData.collateralWei, uint80(collateral), "Collateral should not be changed");
     }
 
-    function test_addCollateral_notRegistered() public {
+    function test_addCollateral_noCollateral() public {
         bytes32 registrationRoot = bytes32(uint256(0));
-        vm.expectRevert(IRegistry.NotRegisteredKey.selector);
+        vm.expectRevert(IRegistry.NoCollateral.selector);
         registry.addCollateral{ value: 1 gwei }(registrationRoot);
     }
 }

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -27,9 +27,9 @@ contract RegisterTester is UnitTestHelper {
     function test_register_insufficientCollateral() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
         vm.expectRevert(IRegistry.InsufficientCollateral.selector);
         registry.register{ value: collateral - 1 }(registrations, operator);
@@ -38,9 +38,9 @@ contract RegisterTester is UnitTestHelper {
     function test_register_OperatorAlreadyRegistered() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -54,9 +54,9 @@ contract RegisterTester is UnitTestHelper {
     function test_verifyMerkleProofHeight1() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -78,11 +78,11 @@ contract RegisterTester is UnitTestHelper {
     function test_verifyMerkleProofHeight2() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](2);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
-        registrations[1] = _createRegistration(SECRET_KEY_2, operator);
+        registrations[1] = _createSignedRegistration(SECRET_KEY_2, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -106,13 +106,13 @@ contract RegisterTester is UnitTestHelper {
     function test_verifyMerkleProofHeight3() public {
         uint256 collateral = 3 * registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](3); // will be padded to 4
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](3); // will be padded to 4
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
-        registrations[1] = _createRegistration(SECRET_KEY_1 + 1, operator);
+        registrations[1] = _createSignedRegistration(SECRET_KEY_1 + 1, operator);
 
-        registrations[2] = _createRegistration(SECRET_KEY_1 + 2, operator);
+        registrations[2] = _createSignedRegistration(SECRET_KEY_1 + 2, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -133,9 +133,9 @@ contract RegisterTester is UnitTestHelper {
         uint256 size = uint256(n);
         uint256 collateral = size * registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](size);
         for (uint256 i = 0; i < size; i++) {
-            registrations[i] = _createRegistration(SECRET_KEY_1 + i, operator);
+            registrations[i] = _createSignedRegistration(SECRET_KEY_1 + i, operator);
         }
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
@@ -164,7 +164,7 @@ contract UnregisterTester is UnitTestHelper {
     function test_unregister() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -181,7 +181,7 @@ contract UnregisterTester is UnitTestHelper {
     function test_unregister_wrongOperator() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -194,7 +194,7 @@ contract UnregisterTester is UnitTestHelper {
     function test_unregister_alreadyUnregistered() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -221,7 +221,7 @@ contract OptInAndOutTester is UnitTestHelper {
     function test_optInAndOut() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -247,7 +247,7 @@ contract OptInAndOutTester is UnitTestHelper {
 
     function test_optInToSlasher_wrongOperator() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         address slasher = address(1234);
@@ -264,7 +264,7 @@ contract OptInAndOutTester is UnitTestHelper {
 
     function test_optInToSlasher_alreadyOptedIn() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         address slasher = address(1234);
@@ -284,7 +284,7 @@ contract OptInAndOutTester is UnitTestHelper {
 
     function test_optOutOfSlasher_wrongOperator() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         address slasher = address(1234);
@@ -305,7 +305,7 @@ contract OptInAndOutTester is UnitTestHelper {
 
     function test_optOutOfSlasher_optInDelayNotMet() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
         address slasher = address(1234);
@@ -338,7 +338,7 @@ contract ClaimCollateralTester is UnitTestHelper {
     function test_claimCollateral() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -364,7 +364,7 @@ contract ClaimCollateralTester is UnitTestHelper {
     function test_claimCollateral_notUnregistered() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -377,7 +377,7 @@ contract ClaimCollateralTester is UnitTestHelper {
     function test_claimCollateral_delayNotMet() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -395,7 +395,7 @@ contract ClaimCollateralTester is UnitTestHelper {
     function test_claimCollateral_alreadyClaimed() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -428,7 +428,7 @@ contract AddCollateralTester is UnitTestHelper {
         uint256 collateral = registry.getConfig().minCollateralWei;
         vm.assume((addAmount + collateral) < uint256(2 ** 80));
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -448,7 +448,7 @@ contract AddCollateralTester is UnitTestHelper {
     function test_addCollateral_overflow() public {
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -486,14 +486,14 @@ contract SlashRegistrationTester is UnitTestHelper {
     function test_slashRegistration_badSignature() public {
         uint256 collateral = 2 * registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](1);
 
         BLS.G1Point memory pubkey = BLS.toPublicKey(SECRET_KEY_1);
 
         // Use a different secret key to sign the registration
         BLS.G2Point memory signature = _registrationSignature(SECRET_KEY_2, operator);
 
-        registrations[0] = IRegistry.Registration({ pubkey: pubkey, signature: signature });
+        registrations[0] = IRegistry.SignedRegistration({ pubkey: pubkey, signature: signature });
 
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator);
 
@@ -537,9 +537,9 @@ contract SlashRegistrationTester is UnitTestHelper {
     function test_slashRegistrationHeight1_DifferentOwner() public {
         uint256 collateral = 2 * registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(
             registrations,
@@ -593,10 +593,10 @@ contract SlashRegistrationTester is UnitTestHelper {
     function test_slashRegistrationHeight2_DifferentOwner() public {
         uint256 collateral = 2 * registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](2);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
-        registrations[1] = _createRegistration(SECRET_KEY_2, operator);
+        registrations[1] = _createSignedRegistration(SECRET_KEY_2, operator);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(
             registrations,
@@ -645,9 +645,9 @@ contract SlashRegistrationTester is UnitTestHelper {
         uint256 size = uint256(n);
         uint256 collateral = registry.getConfig().minCollateralWei;
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](size);
         for (uint256 i = 0; i < size; i++) {
-            registrations[i] = _createRegistration(SECRET_KEY_1 + i, operator);
+            registrations[i] = _createSignedRegistration(SECRET_KEY_1 + i, operator);
         }
 
         bytes32 registrationRoot = registry.register{ value: collateral }(
@@ -703,7 +703,7 @@ contract RentrancyTester is UnitTestHelper {
         ReentrantRegistrationContract reentrantContract = new ReentrantRegistrationContract(address(registry));
         vm.deal(address(reentrantContract), 1000 ether);
 
-        IRegistry.Registration[] memory registrations =
+        IRegistry.SignedRegistration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, address(reentrantContract));
 
         reentrantContract.register(registrations);
@@ -745,9 +745,9 @@ contract RentrancyTester is UnitTestHelper {
             new ReentrantSlashableRegistrationContract(address(registry));
         vm.deal(address(reentrantContract), 1000 ether);
 
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        IRegistry.SignedRegistration[] memory registrations = new IRegistry.SignedRegistration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, operator);
+        registrations[0] = _createSignedRegistration(SECRET_KEY_1, operator);
 
         // frontrun to set withdrawal address to reentrantContract
         reentrantContract.register(registrations);

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -173,7 +173,7 @@ contract UnregisterTester is UnitTestHelper {
         emit IRegistry.OperatorUnregistered(registrationRoot);
         registry.unregister(registrationRoot);
 
-        OperatorData memory operatorData = getRegistrationData(registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(registrationRoot);
         assertEq(operatorData.unregisteredAt, uint48(block.number), "Wrong unregistration block");
         assertEq(operatorData.registeredAt, uint48(block.number), "Wrong registration block"); // Should remain unchanged
     }
@@ -358,7 +358,7 @@ contract ClaimCollateralTester is UnitTestHelper {
         assertEq(operator.balance, balanceBefore + collateral, "Collateral not returned");
 
         // Verify registration was deleted
-        assertEq(getRegistrationData(registrationRoot).deleted, true, "Registration not deleted");
+        assertEq(registry.getOperatorData(registrationRoot).deleted, true, "Registration not deleted");
     }
 
     function test_claimCollateral_notUnregistered() public {
@@ -440,8 +440,9 @@ contract AddCollateralTester is UnitTestHelper {
         emit IRegistry.CollateralAdded(registrationRoot, expectedCollateralWei);
         registry.addCollateral{ value: addAmount }(registrationRoot);
 
-        OperatorData memory operatorData = getRegistrationData(registrationRoot);
-        assertEq(operatorData.collateralWei, expectedCollateralWei, "Collateral not added");
+        assertEq(
+            registry.getOperatorData(registrationRoot).collateralWei, expectedCollateralWei, "Collateral not added"
+        );
     }
 
     function test_addCollateral_overflow() public {
@@ -458,8 +459,11 @@ contract AddCollateralTester is UnitTestHelper {
         vm.expectRevert(IRegistry.CollateralOverflow.selector);
         registry.addCollateral{ value: addAmount }(registrationRoot);
 
-        OperatorData memory operatorData = getRegistrationData(registrationRoot);
-        assertEq(operatorData.collateralWei, uint80(collateral), "Collateral should not be changed");
+        assertEq(
+            registry.getOperatorData(registrationRoot).collateralWei,
+            uint80(collateral),
+            "Collateral should not be changed"
+        );
     }
 
     function test_addCollateral_noCollateral() public {
@@ -527,7 +531,7 @@ contract SlashRegistrationTester is UnitTestHelper {
         );
 
         // ensure operator was deleted
-        assertEq(getRegistrationData(registrationRoot).deleted, true, "operator was not deleted");
+        assertEq(registry.getOperatorData(registrationRoot).deleted, true, "operator was not deleted");
     }
 
     function test_slashRegistrationHeight1_DifferentOwner() public {
@@ -583,7 +587,7 @@ contract SlashRegistrationTester is UnitTestHelper {
         );
 
         // ensure operator was deleted
-        assertEq(getRegistrationData(registrationRoot).deleted, true, "operator was not deleted");
+        assertEq(registry.getOperatorData(registrationRoot).deleted, true, "operator was not deleted");
     }
 
     function test_slashRegistrationHeight2_DifferentOwner() public {
@@ -677,7 +681,7 @@ contract SlashRegistrationTester is UnitTestHelper {
             urcBalanceBefore
         );
 
-        assertEq(getRegistrationData(registrationRoot).deleted, true, "operator was not deleted");
+        assertEq(registry.getOperatorData(registrationRoot).deleted, true, "operator was not deleted");
     }
 }
 
@@ -726,7 +730,9 @@ contract RentrancyTester is UnitTestHelper {
         );
 
         // Verify registration was deleted
-        assertEq(getRegistrationData(reentrantContract.registrationRoot()).deleted, true, "operator was not deleted");
+        assertEq(
+            registry.getOperatorData(reentrantContract.registrationRoot()).deleted, true, "operator was not deleted"
+        );
     }
 
     // For setup we register() -> slashRegistration()

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -350,7 +350,7 @@ contract SlashCommitmentTester is UnitTestHelper {
         );
 
         // verify operator was deleted
-        _assertRegistration(result.registrationRoot, address(0), 0, 0, 0, 0);
+        assertEq(getRegistrationData(result.registrationRoot).deleted, true, "operator was not deleted");
     }
 
     // test multiple slashings

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -65,7 +65,7 @@ contract SlashCommitmentTester is UnitTestHelper {
             basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
         bytes memory evidence = "";
@@ -134,7 +134,7 @@ contract SlashCommitmentTester is UnitTestHelper {
         ISlasher.SignedCommitment memory signedCommitment =
             basicCommitment(params.committerSecretKey, params.slasher, "");
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
         bytes memory evidence = "";
@@ -209,7 +209,7 @@ contract SlashCommitmentTester is UnitTestHelper {
         ISlasher.SignedDelegation memory badSignedDelegation =
             signDelegation(SECRET_KEY_2, result.signedDelegation.delegation);
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
 
@@ -244,7 +244,7 @@ contract SlashCommitmentTester is UnitTestHelper {
         ISlasher.SignedCommitment memory signedCommitment =
             basicCommitment(params.committerSecretKey, params.slasher, "");
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
 
@@ -281,7 +281,7 @@ contract SlashCommitmentTester is UnitTestHelper {
             basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
         bytes memory evidence = "";
@@ -372,7 +372,7 @@ contract SlashCommitmentTester is UnitTestHelper {
             basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
         bytes memory evidence = "";
@@ -722,7 +722,7 @@ contract SlashEquivocationTester is UnitTestHelper {
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
         // Setup proof
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
 
@@ -732,10 +732,10 @@ contract SlashEquivocationTester is UnitTestHelper {
         // Sign delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
             proposer: BLS.toPublicKey(params.proposerSecretKey),
-            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            delegate: BLS.toPublicKey(0), // different delegate
             committer: params.committer,
             slot: params.slot,
-            metadata: "different metadata"
+            metadata: ""
         });
 
         ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
@@ -758,7 +758,9 @@ contract SlashEquivocationTester is UnitTestHelper {
         assertEq(operatorData.collateralWei, (collateral - registry.MIN_COLLATERAL()), "collateralWei not decremented");
 
         assertEq(
-            challenger.balance, challengerBalanceBefore + registry.MIN_COLLATERAL(), "challenger did not receive reward"
+            challenger.balance,
+            challengerBalanceBefore + registry.MIN_COLLATERAL() / 2,
+            "challenger did not receive reward"
         );
     }
 
@@ -777,16 +779,16 @@ contract SlashEquivocationTester is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
-        // Create second delegation with different metadata
+        // Create second delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
             proposer: BLS.toPublicKey(params.proposerSecretKey),
-            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            delegate: BLS.toPublicKey(0), // different delegate
             committer: params.committer,
             slot: params.slot,
-            metadata: "different metadata"
+            metadata: ""
         });
 
         ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
@@ -825,10 +827,10 @@ contract SlashEquivocationTester is UnitTestHelper {
         // Create second delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
             proposer: BLS.toPublicKey(params.proposerSecretKey),
-            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            delegate: BLS.toPublicKey(0), // different delegate
             committer: params.committer,
             slot: params.slot,
-            metadata: "different metadata"
+            metadata: ""
         });
 
         ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
@@ -862,7 +864,7 @@ contract SlashEquivocationTester is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
@@ -894,7 +896,7 @@ contract SlashEquivocationTester is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
         // Create second delegation with different slot
@@ -903,7 +905,7 @@ contract SlashEquivocationTester is UnitTestHelper {
             delegate: BLS.toPublicKey(params.delegateSecretKey),
             committer: params.committer,
             slot: params.slot + 1, // Different slot
-            metadata: "different metadata"
+            metadata: ""
         });
 
         ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
@@ -937,16 +939,16 @@ contract SlashEquivocationTester is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
         // Create second delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
             proposer: BLS.toPublicKey(params.proposerSecretKey),
-            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            delegate: BLS.toPublicKey(0), // different delegate
             committer: params.committer,
             slot: params.slot,
-            metadata: "different metadata"
+            metadata: ""
         });
 
         ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
@@ -965,7 +967,7 @@ contract SlashEquivocationTester is UnitTestHelper {
         );
 
         // Try to slash again with same delegations
-        vm.expectRevert(IRegistry.SlashingAlreadyOccurred.selector);
+        vm.expectRevert(IRegistry.OperatorAlreadyEquivocated.selector);
         registry.slashEquivocation(
             result.registrationRoot,
             result.registrations[0].signature,
@@ -976,7 +978,7 @@ contract SlashEquivocationTester is UnitTestHelper {
         );
 
         // Try reversing the order of the delegations
-        vm.expectRevert(IRegistry.SlashingAlreadyOccurred.selector);
+        vm.expectRevert(IRegistry.OperatorAlreadyEquivocated.selector);
         registry.slashEquivocation(
             result.registrationRoot,
             result.registrations[0].signature,
@@ -1002,16 +1004,16 @@ contract SlashEquivocationTester is UnitTestHelper {
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
         // Create second delegation
         ISlasher.Delegation memory delegationTwo = ISlasher.Delegation({
             proposer: BLS.toPublicKey(params.proposerSecretKey),
-            delegate: BLS.toPublicKey(params.delegateSecretKey),
+            delegate: BLS.toPublicKey(0), // different delegate
             committer: params.committer,
             slot: params.slot,
-            metadata: "different metadata"
+            metadata: ""
         });
 
         ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(params.proposerSecretKey, delegationTwo);
@@ -1078,7 +1080,7 @@ contract SlashReentrantTester is UnitTestHelper {
             basicCommitment(params.committerSecretKey, params.slasher, "");
 
         // Setup proof
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
         // skip past fraud proof window
@@ -1093,10 +1095,10 @@ contract SlashReentrantTester is UnitTestHelper {
             params.proposerSecretKey,
             ISlasher.Delegation({
                 proposer: BLS.toPublicKey(params.proposerSecretKey),
-                delegate: BLS.toPublicKey(params.delegateSecretKey),
+                delegate: BLS.toPublicKey(0), // different delegate
                 committer: params.committer,
                 slot: params.slot,
-                metadata: "different metadata"
+                metadata: ""
             })
         );
 
@@ -1111,7 +1113,7 @@ contract SlashReentrantTester is UnitTestHelper {
             address(registry),
             registry.MIN_COLLATERAL()
         );
-        uint256 gotSlashAmountWei = registry.slashEquivocation(
+        registry.slashEquivocation(
             result.registrationRoot,
             result.registrations[0].signature,
             proof,
@@ -1119,7 +1121,6 @@ contract SlashReentrantTester is UnitTestHelper {
             result.signedDelegation,
             signedDelegationTwo
         );
-        assertEq(registry.MIN_COLLATERAL(), gotSlashAmountWei, "Slash amount incorrect");
 
         OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
 
@@ -1131,15 +1132,22 @@ contract SlashReentrantTester is UnitTestHelper {
         );
 
         assertEq(
-            challenger.balance, challengerBalanceBefore + registry.MIN_COLLATERAL(), "challenger did not receive reward"
+            challenger.balance,
+            challengerBalanceBefore + registry.MIN_COLLATERAL() / 2,
+            "challenger did not receive reward"
         );
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");
 
+        // Verify operator's equivocated is set
+        assertEq(operatorData.equivocated, true, "operator not equivocated");
+
         // Verify operator's collateralGwei is decremented
         assertEq(
-            operatorData.collateralWei, operatorCollateralWeiBefore - gotSlashAmountWei, "collateralWei not decremented"
+            operatorData.collateralWei,
+            operatorCollateralWeiBefore - registry.MIN_COLLATERAL(),
+            "collateralWei not decremented"
         );
     }
 }
@@ -1180,15 +1188,15 @@ contract SlashConditionTester is UnitTestHelper {
             params.proposerSecretKey,
             ISlasher.Delegation({
                 proposer: BLS.toPublicKey(params.proposerSecretKey),
-                delegate: BLS.toPublicKey(params.delegateSecretKey),
+                delegate: BLS.toPublicKey(0), // different delegate
                 committer: params.committer,
                 slot: params.slot,
-                metadata: "different metadata"
+                metadata: ""
             })
         );
 
         // Setup proof
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
 
@@ -1237,15 +1245,15 @@ contract SlashConditionTester is UnitTestHelper {
             params.proposerSecretKey,
             ISlasher.Delegation({
                 proposer: BLS.toPublicKey(params.proposerSecretKey),
-                delegate: BLS.toPublicKey(params.delegateSecretKey),
+                delegate: BLS.toPublicKey(0), // different delegate
                 committer: params.committer,
                 slot: params.slot,
-                metadata: "different metadata"
+                metadata: ""
             })
         );
 
         // Setup proof
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operator);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
 
@@ -1271,6 +1279,7 @@ contract SlashConditionTester is UnitTestHelper {
         // Verify operator was slashed
         OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
         assertEq(operatorData.slashedAt, block.number, "operator not slashed");
+        assertEq(operatorData.equivocated, true, "operator not equivocated");
 
         // Move past unregistration delay
         vm.roll(block.number + registry.UNREGISTRATION_DELAY() + 1);

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -152,7 +152,7 @@ contract SlashCommitmentTester is UnitTestHelper {
         );
     }
 
-    function testRevertNotRegisteredProposer() public {
+    function testRevertInvalidProof() public {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
@@ -175,7 +175,7 @@ contract SlashCommitmentTester is UnitTestHelper {
 
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
-        vm.expectRevert(IRegistry.NotRegisteredKey.selector);
+        vm.expectRevert(IRegistry.InvalidProof.selector);
         registry.slashCommitment(
             result.registrationRoot,
             result.registrations[0].signature,
@@ -805,7 +805,7 @@ contract SlashEquivocationTester is UnitTestHelper {
         );
     }
 
-    function testRevertEquivocationNotRegisteredKey() public {
+    function testRevertEquivocationInvalidProof() public {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
@@ -838,7 +838,7 @@ contract SlashEquivocationTester is UnitTestHelper {
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
         vm.startPrank(challenger);
-        vm.expectRevert(IRegistry.NotRegisteredKey.selector);
+        vm.expectRevert(IRegistry.InvalidProof.selector);
         registry.slashEquivocation(
             result.registrationRoot,
             result.registrations[0].signature,

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -101,7 +101,7 @@ contract SlashCommitmentTester is UnitTestHelper {
 
         _verifySlashCommitmentBalances(challenger, gotSlashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");
@@ -300,7 +300,7 @@ contract SlashCommitmentTester is UnitTestHelper {
             evidence
         );
 
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
         // attempt to claim collateral
         vm.expectRevert(IRegistry.SlashWindowNotMet.selector);
@@ -350,7 +350,7 @@ contract SlashCommitmentTester is UnitTestHelper {
         );
 
         // verify operator was deleted
-        assertEq(getRegistrationData(result.registrationRoot).deleted, true, "operator was not deleted");
+        assertEq(registry.getOperatorData(result.registrationRoot).deleted, true, "operator was not deleted");
     }
 
     // test multiple slashings
@@ -421,11 +421,9 @@ contract SlashCommitmentTester is UnitTestHelper {
             evidence
         );
 
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
-
         // verify operator's collateralGwei is decremented by 2 slashings
         assertEq(
-            operatorData.collateralWei,
+            registry.getOperatorData(result.registrationRoot).collateralWei,
             collateral - 2 * dummySlasher.SLASH_AMOUNT_WEI(),
             "collateralGwei not decremented"
         );
@@ -494,7 +492,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
 
         _verifySlashCommitmentBalances(challenger, gotSlashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");
@@ -750,7 +748,7 @@ contract SlashEquivocationTester is UnitTestHelper {
             signedDelegationTwo
         );
 
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
         // verify operator's collateralGwei is decremented by MIN_COLLATERAL
         assertEq(
@@ -1090,7 +1088,7 @@ contract SlashReentrantTester is UnitTestHelper {
 
         uint256 challengerBalanceBefore = challenger.balance;
         uint256 urcBalanceBefore = address(registry).balance;
-        uint80 operatorCollateralWeiBefore = getRegistrationData(result.registrationRoot).collateralWei;
+        uint80 operatorCollateralWeiBefore = registry.getOperatorData(result.registrationRoot).collateralWei;
 
         // Sign a second delegation to equivocate
         ISlasher.SignedDelegation memory signedDelegationTwo = signDelegation(
@@ -1124,7 +1122,7 @@ contract SlashReentrantTester is UnitTestHelper {
             signedDelegationTwo
         );
 
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
         // verify operator's collateralGwei is decremented by MIN_COLLATERAL
         assertEq(
@@ -1218,7 +1216,7 @@ contract SlashConditionTester is UnitTestHelper {
         vm.stopPrank();
 
         // Verify operator was slashed
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
         assertEq(operatorData.slashedAt, block.number, "operator not slashed");
 
         // Try to unregister after being slashed
@@ -1279,7 +1277,7 @@ contract SlashConditionTester is UnitTestHelper {
         vm.stopPrank();
 
         // Verify operator was slashed
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
         assertEq(operatorData.slashedAt, block.number, "operator not slashed");
         assertEq(operatorData.equivocated, true, "operator not equivocated");
 

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -258,7 +258,7 @@ contract SlashCommitmentTester is UnitTestHelper {
 
         // attempt to slash with same evidence
         vm.startPrank(challenger);
-        vm.expectRevert(IRegistry.SlashingAlreadyOccurred.selector);
+        vm.expectRevert(IRegistry.SlashWindowExpired.selector);
         registry.slashCommitment(proof, result.signedDelegation, signedCommitment, evidence);
 
         // attempt to slash with different SignedCommitment
@@ -398,7 +398,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
             dummySlasher.SLASH_AMOUNT_WEI()
         );
 
-        uint256 gotSlashAmountWei = registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
+        uint256 gotSlashAmountWei = registry.slashCommitment(result.registrationRoot, signedCommitment, "");
 
         assertEq(dummySlasher.SLASH_AMOUNT_WEI(), gotSlashAmountWei, "Slash amount incorrect");
 
@@ -457,7 +457,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash after unregistration delay
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.OperatorAlreadyUnregistered.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
+        registry.slashCommitment(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertSlashWindowExpired() public {
@@ -490,7 +490,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
 
         // First slash
         vm.startPrank(challenger);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
+        registry.slashCommitment(result.registrationRoot, signedCommitment, "");
 
         // Wait for slash window to expire
         vm.roll(block.number + registry.getConfig().slashWindow + 1);
@@ -498,7 +498,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash again after window expired
         signedCommitment = basicCommitment(params.committerSecretKey, params.slasher, "different payload");
         vm.expectRevert(IRegistry.SlashWindowExpired.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
+        registry.slashCommitment(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertNotOptedIn() public {
@@ -525,7 +525,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash without opting in
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.NotOptedIn.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
+        registry.slashCommitment(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertUnauthorizedCommitment() public {
@@ -560,7 +560,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash with unauthorized commitment
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.UnauthorizedCommitment.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
+        registry.slashCommitment(result.registrationRoot, signedCommitment, "");
     }
 
     function testRevertSlashAmountExceedsCollateral() public {
@@ -594,7 +594,7 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Try to slash with amount exceeding collateral
         vm.startPrank(challenger);
         vm.expectRevert(IRegistry.SlashAmountExceedsCollateral.selector);
-        registry.slashCommitmentFromOptIn(result.registrationRoot, signedCommitment, "");
+        registry.slashCommitment(result.registrationRoot, signedCommitment, "");
     }
 }
 

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -502,13 +502,11 @@ contract SlashCommitmentFromOptInTester is UnitTestHelper {
         // Verify operator's collateralGwei is decremented
         assertEq(operatorData.collateralWei, collateral - gotSlashAmountWei, "collateralWei not decremented");
 
-        // Verify the SlasherCommitment mapping is cleared
+        // Verify the SlasherCommitment was set to slashed
         IRegistry.SlasherCommitment memory slasherCommitment =
             registry.getSlasherCommitment(result.registrationRoot, address(dummySlasher));
 
-        assertEq(slasherCommitment.committer, address(0), "SlasherCommitment not cleared");
-        assertEq(slasherCommitment.optedInAt, 0, "SlasherCommitment not cleared");
-        assertEq(slasherCommitment.optedOutAt, 0, "SlasherCommitment not cleared");
+        assertEq(slasherCommitment.slashed, true, "SlasherCommitment not slashed");
     }
 
     function testRevertOperatorAlreadyUnregistered() public {

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -113,7 +113,7 @@ contract SlashCommitmentTester is UnitTestHelper {
         bytes32 slashingDigest =
             keccak256(abi.encode(result.signedDelegation, signedCommitment, result.registrationRoot));
 
-        assertEq(registry.slashedBefore(slashingDigest), true, "slashedBefore not set");
+        assertEq(registry.slashingEvidenceAlreadyUsed(slashingDigest), true, "slashedBefore not set");
     }
 
     function testRevertFraudProofWindowNotMet() public {

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -31,14 +31,14 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
 
     StateLockSlasher slasher;
     BLS.G1Point delegatePubKey;
-    uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
+    uint256 slashAmountWei = 1 ether;
     uint256 collateral = 1.1 ether;
     uint256 committerSecretKey;
     address committer;
 
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
-        slasher = new StateLockSlasher(slashAmountGwei);
+        slasher = new StateLockSlasher(slashAmountWei);
         registry = new Registry();
         (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
@@ -215,9 +215,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
             evidence
         );
 
-        _verifySlashCommitmentBalances(
-            challenger, slashAmountGwei * 1 gwei, 0, challengerBalanceBefore, urcBalanceBefore
-        );
+        _verifySlashCommitmentBalances(challenger, slashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 
         // Retrieve operator data
         OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
@@ -226,7 +224,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");
 
         // Verify operator's collateralGwei is decremented
-        assertEq(operatorData.collateralGwei, collateral / 1 gwei - slashAmountGwei, "collateralGwei not decremented");
+        assertEq(operatorData.collateralWei, collateral - slashAmountWei, "collateralGwei not decremented");
 
         // Verify the slashedBefore mapping is set
         bytes32 slashingDigest =

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -194,8 +194,10 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
             bytes memory evidence
         ) = setupSlash(1);
 
+        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+
         // Merkle proof for URC registration
-        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory leaves = _hashToLeaves(result.registrations, operatorData.owner);
         uint256 leafIndex = 0;
         bytes32[] memory registrationProof = MerkleTree.generateProof(leaves, leafIndex);
 
@@ -218,7 +220,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         _verifySlashCommitmentBalances(challenger, slashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 
         // Retrieve operator data
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        operatorData = getRegistrationData(result.registrationRoot);
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -231,7 +231,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         // Verify the slashedBefore mapping is set
         bytes32 slashingDigest =
             keccak256(abi.encode(result.signedDelegation, signedCommitment, result.registrationRoot));
-        assertEq(registry.slashedBefore(slashingDigest), true, "slashedBefore not set");
+        assertEq(registry.slashingEvidenceAlreadyUsed(slashingDigest), true, "slashedBefore not set");
     }
 
     // =========== Helper functions ===========

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -39,7 +39,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
         slasher = new StateLockSlasher(slashAmountWei);
-        registry = new Registry();
+        registry = new Registry(defaultConfig());
         (committer, committerSecretKey) = makeAddrAndKey("commitmentsKey");
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
         vm.deal(committer, 100 ether);
@@ -141,8 +141,8 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         vm.deal(alice, 100 ether); // Give alice some ETH
 
         // Advance before the fraud proof window
-        vm.roll(exclusionBlockNumber - registry.FRAUD_PROOF_WINDOW());
-        vm.warp(exclusionBlockNumber - registry.FRAUD_PROOF_WINDOW() * 12);
+        vm.roll(exclusionBlockNumber - registry.getConfig().fraudProofWindow);
+        vm.warp(exclusionBlockNumber - registry.getConfig().fraudProofWindow * 12);
 
         // Register and delegate
         result = setupRegistration(alice, delegate, 9994114 - 100);

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -194,7 +194,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
             bytes memory evidence
         ) = setupSlash(1);
 
-        OperatorData memory operatorData = getRegistrationData(result.registrationRoot);
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
         // Merkle proof for URC registration
         bytes32[] memory leaves = _hashToLeaves(result.registrations, operatorData.owner);
@@ -220,7 +220,7 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
         _verifySlashCommitmentBalances(challenger, slashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 
         // Retrieve operator data
-        operatorData = getRegistrationData(result.registrationRoot);
+        operatorData = registry.getOperatorData(result.registrationRoot);
 
         // Verify operator's slashedAt is set
         assertEq(operatorData.slashedAt, block.number, "slashedAt not set");

--- a/test/StateLockSlasher.t.sol
+++ b/test/StateLockSlasher.t.sol
@@ -196,26 +196,16 @@ contract StateLockSlasherTest is UnitTestHelper, PreconfStructs {
 
         IRegistry.OperatorData memory operatorData = registry.getOperatorData(result.registrationRoot);
 
-        // Merkle proof for URC registration
-        bytes32[] memory leaves = _hashToLeaves(result.registrations, operatorData.owner);
-        uint256 leafIndex = 0;
-        bytes32[] memory registrationProof = MerkleTree.generateProof(leaves, leafIndex);
-
         // Save for comparison after slashing
         uint256 challengerBalanceBefore = challenger.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
+        IRegistry.RegistrationProof memory proof =
+            registry.getRegistrationProof(result.registrations, operatorData.owner, 0);
+
         // Slash via URC
         vm.startPrank(challenger);
-        registry.slashCommitment(
-            result.registrationRoot,
-            result.registrations[0].signature,
-            registrationProof,
-            leafIndex,
-            result.signedDelegation,
-            signedCommitment,
-            evidence
-        );
+        registry.slashCommitment(proof, result.signedDelegation, signedCommitment, evidence);
 
         _verifySlashCommitmentBalances(challenger, slashAmountWei, 0, challengerBalanceBefore, urcBalanceBefore);
 

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -41,15 +41,15 @@ contract UnitTestHelper is Test {
     /// @dev Helper to verify operator data matches expected values
     function _assertRegistration(
         bytes32 registrationRoot,
-        address expectedowner,
-        uint56 expectedCollateral,
-        uint32 expectedRegisteredAt,
-        uint32 expectedUnregisteredAt,
-        uint32 expectedSlashedAt
+        address expectedOwner,
+        uint80 expectedCollateral,
+        uint48 expectedRegisteredAt,
+        uint48 expectedUnregisteredAt,
+        uint48 expectedSlashedAt
     ) internal view {
         OperatorData memory operatorData = getRegistrationData(registrationRoot);
-        assertEq(operatorData.owner, expectedowner, "Wrong withdrawal address");
-        assertEq(operatorData.collateralGwei, expectedCollateral, "Wrong collateral amount");
+        assertEq(operatorData.owner, expectedOwner, "Wrong withdrawal address");
+        assertEq(operatorData.collateralWei, expectedCollateral, "Wrong collateral amount");
         assertEq(operatorData.registeredAt, expectedRegisteredAt, "Wrong registration block");
         assertEq(operatorData.unregisteredAt, expectedUnregisteredAt, "Wrong unregistration block");
         assertEq(operatorData.slashedAt, expectedSlashedAt, "Wrong slashed block");
@@ -105,26 +105,26 @@ contract UnitTestHelper is Test {
 
     struct OperatorData {
         address owner;
-        uint56 collateralGwei;
-        uint8 numKeys;
-        uint32 registeredAt;
-        uint32 unregisteredAt;
-        uint32 slashedAt;
+        uint80 collateralWei;
+        uint16 numKeys;
+        uint48 registeredAt;
+        uint48 unregisteredAt;
+        uint48 slashedAt;
     }
 
     function getRegistrationData(bytes32 registrationRoot) public view returns (OperatorData memory) {
         (
             address owner,
-            uint56 collateralGwei,
-            uint8 numKeys,
-            uint32 registeredAt,
-            uint32 unregisteredAt,
-            uint32 slashedAt
+            uint80 collateralWei,
+            uint16 numKeys,
+            uint48 registeredAt,
+            uint48 unregisteredAt,
+            uint48 slashedAt
         ) = registry.registrations(registrationRoot);
 
         return OperatorData({
             owner: owner,
-            collateralGwei: collateralGwei,
+            collateralWei: collateralWei,
             numKeys: numKeys,
             registeredAt: registeredAt,
             unregisteredAt: unregisteredAt,
@@ -140,9 +140,7 @@ contract UnitTestHelper is Test {
 
         registrationRoot = registry.register{ value: collateral }(registrations, owner);
 
-        _assertRegistration(
-            registrationRoot, owner, uint56(collateral / 1 gwei), uint32(block.number), type(uint32).max, 0
-        );
+        _assertRegistration(registrationRoot, owner, uint80(collateral), uint48(block.number), type(uint48).max, 0);
     }
 
     function basicCommitment(uint256 secretKey, address slasher, bytes memory payload)

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -55,10 +55,14 @@ contract UnitTestHelper is Test {
         assertEq(operatorData.slashedAt, expectedSlashedAt, "Wrong slashed block");
     }
 
-    function _hashToLeaves(IRegistry.Registration[] memory _registrations) internal pure returns (bytes32[] memory) {
+    function _hashToLeaves(IRegistry.Registration[] memory _registrations, address _owner)
+        internal
+        pure
+        returns (bytes32[] memory)
+    {
         bytes32[] memory leaves = new bytes32[](_registrations.length);
         for (uint256 i = 0; i < _registrations.length; i++) {
-            leaves[i] = keccak256(abi.encode(_registrations[i]));
+            leaves[i] = keccak256(abi.encode(_registrations[i], _owner));
         }
         return leaves;
     }
@@ -111,6 +115,7 @@ contract UnitTestHelper is Test {
         uint48 unregisteredAt;
         uint48 slashedAt;
         bool deleted;
+        bool equivocated;
     }
 
     function getRegistrationData(bytes32 registrationRoot) public view returns (OperatorData memory) {
@@ -121,7 +126,8 @@ contract UnitTestHelper is Test {
             uint48 registeredAt,
             uint48 unregisteredAt,
             uint48 slashedAt,
-            bool deleted
+            bool deleted,
+            bool equivocated
         ) = registry.registrations(registrationRoot);
 
         return OperatorData({
@@ -131,7 +137,8 @@ contract UnitTestHelper is Test {
             registeredAt: registeredAt,
             unregisteredAt: unregisteredAt,
             slashedAt: slashedAt,
-            deleted: deleted
+            deleted: deleted,
+            equivocated: equivocated
         });
     }
 

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -20,7 +20,7 @@ contract UnitTestHelper is Test {
     uint256 constant SECRET_KEY_1 = 12345;
     uint256 constant SECRET_KEY_2 = 67890;
 
-    function defaultConfig() internal view returns (IRegistry.Config memory) {
+    function defaultConfig() internal pure returns (IRegistry.Config memory) {
         return IRegistry.Config({
             minCollateralWei: 0.1 ether,
             fraudProofWindow: 7200,
@@ -56,8 +56,8 @@ contract UnitTestHelper is Test {
         uint48 expectedRegisteredAt,
         uint48 expectedUnregisteredAt,
         uint48 expectedSlashedAt
-    ) internal view {
-        OperatorData memory operatorData = getRegistrationData(registrationRoot);
+    ) internal {
+        IRegistry.OperatorData memory operatorData = registry.getOperatorData(registrationRoot);
         assertEq(operatorData.owner, expectedOwner, "Wrong withdrawal address");
         assertEq(operatorData.collateralWei, expectedCollateral, "Wrong collateral amount");
         assertEq(operatorData.registeredAt, expectedRegisteredAt, "Wrong registration block");
@@ -96,7 +96,7 @@ contract UnitTestHelper is Test {
         uint256 _challengerBalanceBefore,
         uint256 _operatorBalanceBefore,
         uint256 _urcBalanceBefore
-    ) internal view {
+    ) internal {
         assertEq(_challenger.balance, _challengerBalanceBefore + _rewardAmount, "challenger didn't receive reward");
         assertEq(
             _operator.balance,
@@ -112,44 +112,9 @@ contract UnitTestHelper is Test {
         uint256 _rewardAmount,
         uint256 _challengerBalanceBefore,
         uint256 _urcBalanceBefore
-    ) internal view {
+    ) internal {
         assertEq(_challenger.balance, _challengerBalanceBefore + _rewardAmount, "challenger didn't receive reward");
         assertEq(address(registry).balance, _urcBalanceBefore - _slashedAmount - _rewardAmount, "urc balance incorrect");
-    }
-
-    struct OperatorData {
-        address owner;
-        uint80 collateralWei;
-        uint16 numKeys;
-        uint48 registeredAt;
-        uint48 unregisteredAt;
-        uint48 slashedAt;
-        bool deleted;
-        bool equivocated;
-    }
-
-    function getRegistrationData(bytes32 registrationRoot) public view returns (OperatorData memory) {
-        (
-            address owner,
-            uint80 collateralWei,
-            uint16 numKeys,
-            uint48 registeredAt,
-            uint48 unregisteredAt,
-            uint48 slashedAt,
-            bool deleted,
-            bool equivocated
-        ) = registry.registrations(registrationRoot);
-
-        return OperatorData({
-            owner: owner,
-            collateralWei: collateralWei,
-            numKeys: numKeys,
-            registeredAt: registeredAt,
-            unregisteredAt: unregisteredAt,
-            slashedAt: slashedAt,
-            deleted: deleted,
-            equivocated: equivocated
-        });
     }
 
     function basicRegistration(uint256 secretKey, uint256 collateral, address owner)

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -20,6 +20,16 @@ contract UnitTestHelper is Test {
     uint256 constant SECRET_KEY_1 = 12345;
     uint256 constant SECRET_KEY_2 = 67890;
 
+    function defaultConfig() internal view returns (IRegistry.Config memory) {
+        return IRegistry.Config({
+            minCollateralWei: 0.1 ether,
+            fraudProofWindow: 7200,
+            unregistrationDelay: 7200,
+            slashWindow: 7200,
+            optInDelay: 7200
+        });
+    }
+
     /// @dev Helper to create a BLS signature for a registration
     function _registrationSignature(uint256 secretKey, address owner) internal view returns (BLS.G2Point memory) {
         bytes memory message = abi.encode(owner);


### PR DESCRIPTION
This PR includes optimizations from the OpenZeppelin team and remediations to the audit report from Zellic (sponsored by the Interstate team ❤️).

OpenZeppelin suggestions:

- In lib/MerkleTree.sol , there’s a function called nextPowerOfTwo. I think it’s worth trying to use the following version with OZ’s log2:

  ```solidity
  function nextPowerOf2(uint256 x) internal pure returns (uint256) {
   if (x <= 1) return 1; 
   return 1 << log2(x, Rounding.Ceil);
  }
  ```
  - [x] resolved by https://github.com/eth-fabric/urc/commit/0915a5858fbf555cacfa7bbdeefbdf6d73f46ad2

- In lib/MerkleTree.sol, I think the for loop in between lines 31-34 (nodes[I] = bytes32(0)) is not necessary, may save some gas too
  - [x] resolved by https://github.com/eth-fabric/urc/commit/697f12ac7058d631d42e40f52dd0fb4894e0ee68 and https://github.com/eth-fabric/urc/commit/9c55f0128ce5d29782add126f770c32220c53cbb

- In _merkleizeRegistrations, would it make sense to emit only a single event instead of multiple KeyRegistered? Also think the leaves are not needed since they can always be computed off chain by an indexer
  - [x] resolved by https://github.com/eth-fabric/urc/commit/c73bd56779c71947aff0902e9d6ef6d9e1f88126

- In the register function, isn’t it possible to have ETH stuck in the contract if a value that’s not divisible by 1 gwei is input?
  - [x] resolved by https://github.com/eth-fabric/urc/commit/e7d0fa9cd62150de0dd9da4cf1051c4e29628a45

- Related to the previous point, but, is there a benefit to store the ETH in gwei instead of just wei? I feel uint56 may be enough if the min collateral is 0.1 ETH (2**56/1e18 = 0.07 ETH). Note that the Operator struct already spans over 3 slots, so it may be worth extending the collateralGwei to uint64 (and rename to just `collateralWei`)
  - [x] resolved by https://github.com/eth-fabric/urc/commit/e7d0fa9cd62150de0dd9da4cf1051c4e29628a45
 
- In the Operator struct, the dates (i.e. registeredAt, unregisteredAt, slashedAt) are represented as uint32. This is enough for 1282 years considering 12-second blocks, but it’s not the most future-proof version, we use uint48 at OZ for these
  - [x] resolved by https://github.com/eth-fabric/urc/commit/e7d0fa9cd62150de0dd9da4cf1051c4e29628a45

- Can those dates be represented by an enum of DateType for registered, unregistered and slashed, along with the value. I feel that might make us able to pack Operator within 2 slots. Not sure how relevant is to keep all those block numbers if they’re indexed by the events.
  - [x] block numbers are needed by URC functions or consuming contracts 

- On the OperatorUnregistered event, is the unregisteredAt needed? Indexers have access to the block number at that point.
  - [x] resolved by https://github.com/eth-fabric/urc/commit/554cc1a2d6bf7d3c76dff0ad66a981df873f2d91

- In slashRegistrations, watch out that delete registrations[registrationRoot] at line 246 might not have the expected behavior, see: https://github.com/crytic/slither/wiki/Detector-Documentation#deletion-on-mapping-containing-a-structure
  - [x] resolved by https://github.com/eth-fabric/urc/commit/32bcbba8cd08df65664db518121cd94b924ef3f3
- In slashRegistrations, both .call operations sending value can be replaced with assembly to avoid copying memory for either the empty bytes sent and the return values. That will shave some gas there (Same for other .call operations with value). Similar to:
  ```solidity
  assembly ("memory-safe") {
      success := call(gas(), to, value, 0, 0, 0, 0)
  }
  ```
  - [x] resolved by https://github.com/eth-fabric/urc/commit/70d8538367e8973872af0452e01b78aebc088022

- Is the timestamp in CollateralRecord used? I think that may be removed too if off chain indexers can take care. That would redice the CollateralRecord to a single EVM word that doesn’t allocate memory
  - [x] it is used by consuming contracts so it is insufficient to rely on an indexer

--- 
